### PR TITLE
Fix product modal duplication and highlight color

### DIFF
--- a/catalogo/static/catalogo/style.css
+++ b/catalogo/static/catalogo/style.css
@@ -42,6 +42,17 @@ body {
     border-color: #3b82f6;
     transform: scale(1.1);
     box-shadow: 0 0 0 3px white, 0 0 0 5px #3b82f6;
+    position: relative;
+}
+.color-swatch.selected::after {
+    content: "\2713";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: white;
+    font-size: 1.5rem;
+    font-weight: bold;
 }
 .cart-bounce {
     animation: bounce 0.6s ease;

--- a/catalogo/templates/catalogo/catalogo.html
+++ b/catalogo/templates/catalogo/catalogo.html
@@ -97,14 +97,6 @@
                 <button id="modal-quantity-plus" class="w-14 h-14 text-4xl font-bold text-blue-600 rounded-lg">+</button>
             </div>
         </div>
-        <div>
-            <h3 class="text-xl font-bold mb-3">2. Elige el Tamaño:</h3>
-            <div id="modal-product-sizes" class="flex flex-wrap gap-3"></div>
-        </div>
-        <div>
-            <h3 class="text-xl font-bold mb-3">3. Elige el Color:</h3>
-            <div id="modal-product-colors" class="flex flex-wrap gap-3"></div>
-        </div>
     </div>
     <div class="absolute bottom-0 left-0 right-0 p-4 bg-white border-t border-gray-200">
         <button id="modal-add-to-cart-btn" class="w-full bg-blue-600 text-white text-xl font-bold py-4 px-6 rounded-lg shadow-lg hover:bg-blue-700 transition-all disabled:bg-gray-400 disabled:cursor-not-allowed">Selecciona tamaño y color</button>


### PR DESCRIPTION
## Summary
- show checkmark on selected color swatch
- remove duplicated attribute sections from the product modal

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6860a6764e0c832c93d310d3c5754a2d