### PR TITLE
Fix client registration and improve attribute selection

### DIFF
--- a/catalogo/migrations/0004_cliente_id_autofield.py
+++ b/catalogo/migrations/0004_cliente_id_autofield.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('catalogo', '0003_tipoproducto_imagen'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cliente',
+            name='id',
+            field=models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID', default=1),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='cliente',
+            name='telefono',
+            field=models.CharField(max_length=20, db_index=True),
+        ),
+    ]

--- a/catalogo/models.py
+++ b/catalogo/models.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 
 class Cliente(models.Model):
     """Información del cliente que realiza pedidos."""
-    telefono = models.CharField(primary_key=True, max_length=20)
+    telefono = models.CharField(max_length=20, db_index=True)
     nombre = models.CharField(max_length=150)
     direccion = models.CharField(max_length=255, blank=True)
     ciudad = models.CharField(max_length=100, blank=True)

--- a/catalogo/static/catalogo/script.js
+++ b/catalogo/static/catalogo/script.js
@@ -95,6 +95,20 @@ document.addEventListener('DOMContentLoaded', () => {
         const { productoId, selectedAtributos } = state.modalSelection;
 
         const variacionesDisponibles = DATA.variacionesProducto.filter(v => v.productoId === productoId);
+        const allOptions = modalProductAttributesContainer.querySelectorAll('[data-valor-id]');
+        allOptions.forEach(opt => {
+            const defId = Number(opt.dataset.atributoDefId);
+            const valId = Number(opt.dataset.valorId);
+            const match = variacionesDisponibles.some(v => {
+                if (!v.valorAtributoIds.includes(valId)) return false;
+                return Object.entries(selectedAtributos).every(([d, vId]) => {
+                    if (Number(d) === defId) return true;
+                    return v.valorAtributoIds.includes(vId);
+                });
+            });
+            opt.classList.toggle('opacity-30', !match);
+            opt.classList.toggle('pointer-events-none', !match);
+        });
         const totalAtributosRequeridos = [...new Set(variacionesDisponibles.flatMap(v => v.valorAtributoIds).map(valId => DATA.valorAtributos.find(v => v.id === valId).atributoDefId))].length;
 
         let variation = null;

--- a/catalogo/static/catalogo/style.css
+++ b/catalogo/static/catalogo/style.css
@@ -42,6 +42,17 @@ body {
     border-color: #3b82f6;
     transform: scale(1.1);
     box-shadow: 0 0 0 3px white, 0 0 0 5px #3b82f6;
+    position: relative;
+}
+.color-swatch.selected::after {
+    content: "\2713";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: white;
+    font-size: 1.5rem;
+    font-weight: bold;
 }
 .cart-bounce {
     animation: bounce 0.6s ease;

--- a/catalogo/templates/catalogo/catalogo.html
+++ b/catalogo/templates/catalogo/catalogo.html
@@ -97,14 +97,6 @@
                 <button id="modal-quantity-plus" class="w-14 h-14 text-4xl font-bold text-blue-600 rounded-lg">+</button>
             </div>
         </div>
-        <div>
-            <h3 class="text-xl font-bold mb-3">2. Elige el Tamaño:</h3>
-            <div id="modal-product-sizes" class="flex flex-wrap gap-3"></div>
-        </div>
-        <div>
-            <h3 class="text-xl font-bold mb-3">3. Elige el Color:</h3>
-            <div id="modal-product-colors" class="flex flex-wrap gap-3"></div>
-        </div>
     </div>
     <div class="absolute bottom-0 left-0 right-0 p-4 bg-white border-t border-gray-200">
         <button id="modal-add-to-cart-btn" class="w-full bg-blue-600 text-white text-xl font-bold py-4 px-6 rounded-lg shadow-lg hover:bg-blue-700 transition-all disabled:bg-gray-400 disabled:cursor-not-allowed">Selecciona tamaño y color</button>

--- a/catalogo/views.py
+++ b/catalogo/views.py
@@ -86,9 +86,8 @@ def cliente_detail(request):
     phone = request.GET.get('phone')
     if not phone:
         return HttpResponseBadRequest('phone required')
-    try:
-        cliente = Cliente.objects.get(telefono=phone)
-    except Cliente.DoesNotExist:
+    cliente = Cliente.objects.filter(telefono=phone).order_by('-id').first()
+    if not cliente:
         return HttpResponseNotFound()
     return JsonResponse({
         'phone': cliente.telefono,
@@ -107,11 +106,12 @@ def cliente_create(request):
     phone = payload.get('phone', '').strip()
     if not phone:
         return HttpResponseBadRequest('phone required')
-    cliente, _ = Cliente.objects.get_or_create(telefono=phone)
-    cliente.nombre = payload.get('name', cliente.nombre)
-    cliente.direccion = payload.get('address', cliente.direccion)
-    cliente.ciudad = payload.get('city', cliente.ciudad)
-    cliente.save()
+    cliente = Cliente.objects.create(
+        telefono=phone,
+        nombre=payload.get('name', ''),
+        direccion=payload.get('address', ''),
+        ciudad=payload.get('city', ''),
+    )
     return JsonResponse({
         'phone': cliente.telefono,
         'name': cliente.nombre,


### PR DESCRIPTION
## Summary
- allow duplicate phone numbers by using an auto-increment id
- update client API to create new records and fetch latest by phone
- add migration for new primary key
- filter unavailable variation options in product modal

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6860a6764e0c832c93d310d3c5754a2d