### PR TITLE
Implement admin dashboard and improve cart UX

### DIFF
--- a/catalogo/forms.py
+++ b/catalogo/forms.py
@@ -1,0 +1,23 @@
+from django import forms
+from .models import TipoProducto, Categoria, Producto, VariacionProducto, ValorAtributo
+
+class TipoProductoForm(forms.ModelForm):
+    class Meta:
+        model = TipoProducto
+        fields = ['nombre', 'descripcion', 'imagen_url']
+
+class CategoriaForm(forms.ModelForm):
+    class Meta:
+        model = Categoria
+        fields = ['tipo_producto', 'nombre', 'descripcion', 'imagen_url']
+
+class ProductoForm(forms.ModelForm):
+    class Meta:
+        model = Producto
+        fields = ['categoria', 'referencia', 'nombre', 'foto_url']
+
+class VariacionProductoForm(forms.ModelForm):
+    valores = forms.ModelMultipleChoiceField(queryset=ValorAtributo.objects.all())
+    class Meta:
+        model = VariacionProducto
+        fields = ['producto', 'precio_base', 'valores']

--- a/catalogo/templates/catalogo/admin_dashboard.html
+++ b/catalogo/templates/catalogo/admin_dashboard.html
@@ -1,0 +1,66 @@
+{% extends 'base.html' %}
+{% block title %}Admin Catalogo{% endblock %}
+{% block content %}
+<div class="max-w-4xl mx-auto space-y-8">
+  <h1 class="text-2xl font-bold">Pedidos</h1>
+  <table class="min-w-full bg-white text-black">
+    <thead><tr><th>ID</th><th>Cliente</th><th>Estado</th><th>Cambiar</th></tr></thead>
+    <tbody>
+      {% for p in pedidos %}
+      <tr class="border-b">
+        <td>{{ p.id }}</td>
+        <td>{{ p.cliente.nombre }} - {{ p.cliente.telefono }} - {{ p.cliente.direccion }}</td>
+        <td>{{ p.get_estado_display }}</td>
+        <td>
+          <form method="post" action="{% url 'catalogo:actualizar_estado_pedido' p.id %}">
+            {% csrf_token %}
+            <select name="estado" class="border p-1 text-sm">
+              {% for key, val in estados %}
+                <option value="{{ key }}" {% if key == p.estado %}selected{% endif %}>{{ val }}</option>
+              {% endfor %}
+            </select>
+            <button class="bg-blue-500 text-white px-2 text-sm">Guardar</button>
+          </form>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <h2 class="text-xl font-bold mt-8">Agregar Contenido</h2>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <div>
+      <h3 class="font-semibold">Tipo de Producto</h3>
+      <form method="post" class="space-y-2">
+        {% csrf_token %}
+        {{ tipo_form.as_p }}
+        <button class="bg-green-500 text-white px-4 py-1">Guardar</button>
+      </form>
+    </div>
+    <div>
+      <h3 class="font-semibold">Categoria</h3>
+      <form method="post" class="space-y-2">
+        {% csrf_token %}
+        {{ categoria_form.as_p }}
+        <button class="bg-green-500 text-white px-4 py-1">Guardar</button>
+      </form>
+    </div>
+    <div>
+      <h3 class="font-semibold">Producto</h3>
+      <form method="post" class="space-y-2">
+        {% csrf_token %}
+        {{ producto_form.as_p }}
+        <button class="bg-green-500 text-white px-4 py-1">Guardar</button>
+      </form>
+    </div>
+    <div>
+      <h3 class="font-semibold">Variación</h3>
+      <form method="post" class="space-y-2">
+        {% csrf_token %}
+        {{ variacion_form.as_p }}
+        <button class="bg-green-500 text-white px-4 py-1">Guardar</button>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/catalogo/templates/catalogo/catalogo.html
+++ b/catalogo/templates/catalogo/catalogo.html
@@ -28,6 +28,7 @@
     </button>
 </header>
 <main id="main-content">
+    <nav id="breadcrumb" class="text-sm text-blue-600 mb-4 hidden"></nav>
     <div id="login-page" class="page">
         <h2 class="text-2xl font-bold mb-6 text-center">Bienvenido/a</h2>
         <div class="bg-white p-8 rounded-xl shadow-md max-w-md mx-auto">
@@ -54,6 +55,7 @@
         </div>
     </div>
     <div id="categories-page" class="page hidden">
+        <button id="back-to-types" class="mb-6 text-blue-600 font-bold text-lg hover:underline">← Volver a Tipos</button>
         <h2 class="text-2xl font-bold mb-6">Explora nuestras categorías</h2>
         <div id="categories-grid" class="grid grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6"></div>
     </div>

--- a/catalogo/urls.py
+++ b/catalogo/urls.py
@@ -7,5 +7,8 @@ urlpatterns = [
     path('', views.catalogo_view, name='catalogo'),
     path('api/cliente/', views.cliente_create, name='cliente_create'),
     path('api/cliente/detail/', views.cliente_detail, name='cliente_detail'),
+    path('api/pedido/', views.pedido_create, name='pedido_create'),
+    path('admin/', views.admin_dashboard, name='admin_dashboard'),
+    path('admin/pedido/<int:pedido_id>/estado/', views.actualizar_estado_pedido, name='actualizar_estado_pedido'),
 
     ]


### PR DESCRIPTION
## Summary
- add breadcrumb navigation and back-to-types button
- allow removing items from the cart
- store orders via new `/catalogo/api/pedido/` endpoint
- add admin dashboard to manage orders and add catalog data

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686181de701c832c8a5875c09a4613a8