### PR TITLE
Refactor admin UX and fix checkout

### DIFF
--- a/catalogo/static/catalogo/script.js
+++ b/catalogo/static/catalogo/script.js
@@ -287,11 +287,15 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         message += `*TOTAL DEL PEDIDO: $${total.toLocaleString('es-CO')}*\n\n`;
         message += `*Datos de Envío:*\n- Nombre: ${state.currentUser.name}\n- Dirección: ${state.currentUser.address}\n- Teléfono: ${state.currentUser.phone}\n\n¡Gracias!`;
-        await fetch('/catalogo/api/pedido/', {
+        const response = await fetch('/catalogo/api/pedido/', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCookie('csrftoken') },
             body: JSON.stringify({ cliente: state.currentUser, items })
         });
+        if (!response.ok) {
+            alert('Error guardando el pedido. Inténtalo de nuevo.');
+            return;
+        }
         const whatsappUrl = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponent(message)}`;
         window.open(whatsappUrl, '_blank');
         state.cart = { items: [], appliedPromoCode: null };

--- a/catalogo/templates/catalogo/admin_dashboard.html
+++ b/catalogo/templates/catalogo/admin_dashboard.html
@@ -2,7 +2,17 @@
 {% extends 'catalogo/admin_base.html' %}
 {% block title %}Administración{% endblock %}
 {% block content %}
+<nav class="mb-6 border-b">
+  <ul class="flex gap-4">
+    <li><a href="{% url 'catalogo:admin_dashboard' %}?section=pedidos" class="pb-2 {% if section == 'pedidos' %}font-bold border-b-2 border-blue-500{% endif %}">Pedidos</a></li>
+    <li><a href="{% url 'catalogo:admin_dashboard' %}?section=tipo" class="pb-2 {% if section == 'tipo' %}font-bold border-b-2 border-blue-500{% endif %}">Tipos</a></li>
+    <li><a href="{% url 'catalogo:admin_dashboard' %}?section=categoria" class="pb-2 {% if section == 'categoria' %}font-bold border-b-2 border-blue-500{% endif %}">Categorías</a></li>
+    <li><a href="{% url 'catalogo:admin_dashboard' %}?section=producto" class="pb-2 {% if section == 'producto' %}font-bold border-b-2 border-blue-500{% endif %}">Productos</a></li>
+    <li><a href="{% url 'catalogo:admin_dashboard' %}?section=variacion" class="pb-2 {% if section == 'variacion' %}font-bold border-b-2 border-blue-500{% endif %}">Variaciones</a></li>
+  </ul>
+</nav>
 <div class="space-y-8">
+  {% if section == 'pedidos' %}
   <h1 class="text-2xl font-bold">Pedidos</h1>
   <table class="min-w-full bg-white text-black rounded shadow">
 
@@ -33,49 +43,35 @@
     </tbody>
   </table>
 
-  <h2 class="text-xl font-bold mt-8">Agregar Contenido</h2>
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-
-    <div class="bg-white p-4 rounded shadow space-y-2">
-
-      <h3 class="font-semibold">Tipo de Producto</h3>
-      <form method="post" class="space-y-2">
-        {% csrf_token %}
-        {{ tipo_form.as_p }}
-        <button class="bg-green-500 text-white px-4 py-1">Guardar</button>
-      </form>
-    </div>
-
-    <div class="bg-white p-4 rounded shadow space-y-2">
-
-      <h3 class="font-semibold">Categoria</h3>
-      <form method="post" class="space-y-2">
-        {% csrf_token %}
-        {{ categoria_form.as_p }}
-        <button class="bg-green-500 text-white px-4 py-1">Guardar</button>
-      </form>
-    </div>
-
-    <div class="bg-white p-4 rounded shadow space-y-2">
-
-      <h3 class="font-semibold">Producto</h3>
-      <form method="post" class="space-y-2">
-        {% csrf_token %}
-        {{ producto_form.as_p }}
-        <button class="bg-green-500 text-white px-4 py-1">Guardar</button>
-      </form>
-    </div>
-
-    <div class="bg-white p-4 rounded shadow space-y-2">
-
-      <h3 class="font-semibold">Variación</h3>
-      <form method="post" class="space-y-2">
-        {% csrf_token %}
-        {{ variacion_form.as_p }}
-        <button class="bg-green-500 text-white px-4 py-1">Guardar</button>
-      </form>
-    </div>
-  </div>
+  {% elif section == 'tipo' %}
+  <h2 class="text-xl font-bold">Nuevo Tipo de Producto</h2>
+  <form method="post" class="space-y-2 bg-white p-4 rounded shadow">
+    {% csrf_token %}
+    {{ tipo_form.as_p }}
+    <button class="bg-green-500 text-white px-4 py-1">Guardar</button>
+  </form>
+  {% elif section == 'categoria' %}
+  <h2 class="text-xl font-bold">Nueva Categoría</h2>
+  <form method="post" class="space-y-2 bg-white p-4 rounded shadow">
+    {% csrf_token %}
+    {{ categoria_form.as_p }}
+    <button class="bg-green-500 text-white px-4 py-1">Guardar</button>
+  </form>
+  {% elif section == 'producto' %}
+  <h2 class="text-xl font-bold">Nuevo Producto</h2>
+  <form method="post" class="space-y-2 bg-white p-4 rounded shadow">
+    {% csrf_token %}
+    {{ producto_form.as_p }}
+    <button class="bg-green-500 text-white px-4 py-1">Guardar</button>
+  </form>
+  {% elif section == 'variacion' %}
+  <h2 class="text-xl font-bold">Nueva Variación</h2>
+  <form method="post" class="space-y-2 bg-white p-4 rounded shadow">
+    {% csrf_token %}
+    {{ variacion_form.as_p }}
+    <button class="bg-green-500 text-white px-4 py-1">Guardar</button>
+  </form>
+  {% endif %}
 </div>
 {% endblock %}
 

--- a/catalogo/views.py
+++ b/catalogo/views.py
@@ -2,6 +2,7 @@
 import json
 from django.http import JsonResponse, HttpResponseBadRequest, HttpResponseNotFound
 from django.shortcuts import render, redirect
+from django.urls import reverse
 from django.views.decorators.http import require_http_methods
 from .forms import TipoProductoForm, CategoriaForm, ProductoForm, VariacionProductoForm
 from .models import (
@@ -158,6 +159,7 @@ def pedido_create(request):
 
 
 def admin_dashboard(request):
+    section = request.GET.get('section', 'pedidos')
     tipo_form = TipoProductoForm(prefix='tipo')
     categoria_form = CategoriaForm(prefix='cat')
     producto_form = ProductoForm(prefix='prod')
@@ -168,22 +170,22 @@ def admin_dashboard(request):
             tipo_form = TipoProductoForm(request.POST, prefix='tipo')
             if tipo_form.is_valid():
                 tipo_form.save()
-                return redirect('catalogo:admin_dashboard')
+                return redirect(f"{reverse('catalogo:admin_dashboard')}?section=tipo")
         if 'cat-nombre' in request.POST:
             categoria_form = CategoriaForm(request.POST, prefix='cat')
             if categoria_form.is_valid():
                 categoria_form.save()
-                return redirect('catalogo:admin_dashboard')
+                return redirect(f"{reverse('catalogo:admin_dashboard')}?section=categoria")
         if 'prod-nombre' in request.POST:
             producto_form = ProductoForm(request.POST, prefix='prod')
             if producto_form.is_valid():
                 producto_form.save()
-                return redirect('catalogo:admin_dashboard')
+                return redirect(f"{reverse('catalogo:admin_dashboard')}?section=producto")
         if 'var-precio_base' in request.POST:
             variacion_form = VariacionProductoForm(request.POST, prefix='var')
             if variacion_form.is_valid():
                 variacion_form.save()
-                return redirect('catalogo:admin_dashboard')
+                return redirect(f"{reverse('catalogo:admin_dashboard')}?section=variacion")
 
     pedidos = Pedido.objects.select_related('cliente').all().order_by('-fecha')
     from .models import EstadoPedido
@@ -194,6 +196,7 @@ def admin_dashboard(request):
         'producto_form': producto_form,
         'variacion_form': variacion_form,
         'estados': EstadoPedido.choices,
+        'section': section,
     })
 
 


### PR DESCRIPTION
## Summary
- add navigation sections for catalog admin
- update admin template accordingly
- validate checkout API request before sending order to WhatsApp

## Testing
- `pytest -q`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68618eea9788832cafb71baef4ccca74