### PR TITLE
Improve admin panel cards with editing

### DIFF
--- a/catalogo/forms.py
+++ b/catalogo/forms.py
@@ -1,5 +1,12 @@
 from django import forms
-from .models import TipoProducto, Categoria, Producto, VariacionProducto, ValorAtributo
+from .models import (
+    TipoProducto,
+    Categoria,
+    Producto,
+    AtributoDef,
+    ValorAtributo,
+    VariacionProducto,
+)
 
 
 
@@ -33,11 +40,48 @@ class ProductoForm(BaseStyledForm):
         fields = ['categoria', 'referencia', 'nombre', 'foto_url']
 
 
+class AtributoDefForm(BaseStyledForm):
+
+    class Meta:
+        model = AtributoDef
+        fields = ['tipo_producto', 'nombre']
+
+
+class ValorAtributoForm(BaseStyledForm):
+
+    class Meta:
+        model = ValorAtributo
+        fields = ['atributo_def', 'valor', 'display']
+
+
 class VariacionProductoForm(BaseStyledForm):
     valores = forms.ModelMultipleChoiceField(
-        queryset=ValorAtributo.objects.all(),
+        queryset=ValorAtributo.objects.none(),
         widget=forms.SelectMultiple(attrs={"class": "border rounded p-2 w-full"}),
     )
+
+    def __init__(self, *args, **kwargs):
+        """Filtra los valores según el producto seleccionado."""
+        super().__init__(*args, **kwargs)
+
+        producto_id = None
+        field_name = 'producto'
+        if self.prefix:
+            field_name = f'{self.prefix}-{field_name}'
+        if self.data.get(field_name):
+            producto_id = self.data.get(field_name)
+        elif self.instance.pk:
+            producto_id = self.instance.producto_id
+
+        if producto_id:
+            try:
+                producto = Producto.objects.select_related('categoria__tipo_producto').get(pk=producto_id)
+                tipo_id = producto.categoria.tipo_producto_id
+                self.fields['valores'].queryset = ValorAtributo.objects.filter(
+                    atributo_def__tipo_producto_id=tipo_id
+                )
+            except Producto.DoesNotExist:
+                self.fields['valores'].queryset = ValorAtributo.objects.none()
 
     class Meta:
         model = VariacionProducto

--- a/catalogo/models.py
+++ b/catalogo/models.py
@@ -45,7 +45,8 @@ class Categoria(models.Model):
         ordering = ["nombre"]
 
     def __str__(self):
-        return self.nombre
+        # Mostrar el tipo de producto para que sea más claro en formularios
+        return f"{self.tipo_producto.nombre} - {self.nombre}"
 
 
 class Producto(models.Model):
@@ -59,7 +60,8 @@ class Producto(models.Model):
         ordering = ["nombre"]
 
     def __str__(self):
-        return self.nombre
+        # Mostrar la categoría para una mejor referencia en el admin
+        return f"{self.categoria.nombre} - {self.nombre}"
 
 
 class AtributoDef(models.Model):

--- a/catalogo/templates/catalogo/admin_dashboard.html
+++ b/catalogo/templates/catalogo/admin_dashboard.html
@@ -17,6 +17,8 @@
     <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=categoria" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'categoria' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Categorías</a></li>
     <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=producto" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'producto' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Productos</a></li>
     <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=variacion" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'variacion' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Variaciones</a></li>
+    <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=atributo" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'atributo' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Atributos</a></li>
+    <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=valor" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'valor' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Valores</a></li>
     <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=cliente" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'cliente' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Clientes</a></li>
   </ul>
 </nav>
@@ -119,13 +121,220 @@
     </table>
   </div>
   {% else %}
-  <!-- ... resto de las secciones (tipo, categoria, etc.) sin cambios ... -->
-  <div class="bg-white p-6 rounded-lg shadow max-w-lg">
-    {% if section == 'tipo' %}<h2 class="text-2xl font-bold text-gray-800">Nuevo Tipo de Producto</h2><form method="post" class="space-y-4 mt-4">{% csrf_token %}{{ tipo_form.as_p }}<button type="submit" class="bg-green-500 text-white px-4 py-2 rounded-md font-bold hover:bg-green-600 transition-colors">Guardar Tipo</button></form>{% endif %}
-    {% if section == 'categoria' %}<h2 class="text-2xl font-bold text-gray-800">Nueva Categoría</h2><form method="post" class="space-y-4 mt-4">{% csrf_token %}{{ categoria_form.as_p }}<button type="submit" class="bg-green-500 text-white px-4 py-2 rounded-md font-bold hover:bg-green-600 transition-colors">Guardar Categoría</button></form>{% endif %}
-    {% if section == 'producto' %}<h2 class="text-2xl font-bold text-gray-800">Nuevo Producto</h2><form method="post" class="space-y-4 mt-4">{% csrf_token %}{{ producto_form.as_p }}<button type="submit" class="bg-green-500 text-white px-4 py-2 rounded-md font-bold hover:bg-green-600 transition-colors">Guardar Producto</button></form>{% endif %}
-    {% if section == 'variacion' %}<h2 class="text-2xl font-bold text-gray-800">Nueva Variación</h2><form method="post" class="space-y-4 mt-4">{% csrf_token %}{{ variacion_form.as_p }}<button type="submit" class="bg-green-500 text-white px-4 py-2 rounded-md font-bold hover:bg-green-600 transition-colors">Guardar Variación</button></form>{% endif %}
-    {% if section == 'cliente' %}<h2 class="text-2xl font-bold text-gray-800">Clientes Registrados</h2><div class="overflow-x-auto bg-white rounded-lg shadow mt-4"><table class="min-w-full text-sm text-left text-gray-700"><thead class="bg-gray-100 text-xs text-gray-700 uppercase"><tr><th class="px-6 py-3">ID</th><th class="px-6 py-3">Nombre</th><th class="px-6 py-3">Teléfono</th><th class="px-6 py-3">Dirección</th></tr></thead><tbody>{% for c in clientes %}<tr class="border-b hover:bg-gray-50"><td class="px-6 py-4">{{ c.id }}</td><td class="px-6 py-4">{{ c.nombre }}</td><td class="px-6 py-4">{{ c.telefono }}</td><td class="px-6 py-4">{{ c.direccion }}, {{ c.ciudad }}</td></tr>{% endfor %}</tbody></table></div>{% endif %}
+  <div class="space-y-8">
+    {% if section == 'tipo' %}
+      <h2 class="text-2xl font-bold text-gray-800">Tipos de Producto</h2>
+        <div class="md:flex gap-4">
+        <div class="md:w-3/4 grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {% for t in tipos %}
+          <div class="bg-white p-4 rounded-lg shadow">
+            <h3 class="font-semibold">{{ t.nombre }}</h3>
+            <div class="mt-2 flex justify-end gap-2 text-xs">
+              <a href="?section=tipo&edit_tipo={{ t.id }}" onclick="return confirm('Editar este tipo puede afectar categorías y productos asociados. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
+              <form method="post" onsubmit="return confirm('Eliminar este tipo eliminará sus categorías y productos asociados. ¿Continuar?');">
+                {% csrf_token %}
+                <input type="hidden" name="delete_tipo" value="{{ t.id }}">
+                <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
+              </form>
+            </div>
+          </div>
+          {% empty %}
+          <p class="text-gray-500 col-span-full">No hay tipos registrados.</p>
+          {% endfor %}
+        </div>
+        <div class="md:w-1/4 mt-4 md:mt-0">
+          <div class="bg-white p-6 rounded-lg shadow">
+            <h2 class="text-xl font-bold text-gray-800">{% if edit_tipo %}Editar Tipo{% else %}Nuevo Tipo de Producto{% endif %}</h2>
+            <form method="post" class="space-y-4 mt-4">
+              {% csrf_token %}
+              {{ tipo_form.as_p }}
+              <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded-md font-bold hover:bg-green-600 transition-colors">Guardar</button>
+              {% if edit_tipo %}<a href="?section=tipo" class="ml-2 text-sm">Cancelar</a>{% endif %}
+            </form>
+          </div>
+        </div>
+      </div>
+    {% elif section == 'categoria' %}
+      <h2 class="text-2xl font-bold text-gray-800">Categorías</h2>
+      <div class="md:flex gap-4">
+        <div class="md:w-3/4 grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {% for c in categorias %}
+          <div class="bg-white p-4 rounded-lg shadow">
+            <h3 class="font-semibold">{{ c.nombre }}</h3>
+            <p class="text-sm text-gray-500">{{ c.tipo_producto.nombre }}</p>
+            <div class="mt-2 flex justify-end gap-2 text-xs">
+              <a href="?section=categoria&edit_cat={{ c.id }}" onclick="return confirm('Editar esta categoría puede afectar productos asociados. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
+              <form method="post" onsubmit="return confirm('Eliminar esta categoría eliminará los productos asociados. ¿Continuar?');">
+                {% csrf_token %}
+                <input type="hidden" name="delete_cat" value="{{ c.id }}">
+                <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
+              </form>
+            </div>
+          </div>
+          {% empty %}
+          <p class="text-gray-500 col-span-full">No hay categorías registradas.</p>
+          {% endfor %}
+        </div>
+        <div class="md:w-1/4 mt-4 md:mt-0">
+          <div class="bg-white p-6 rounded-lg shadow">
+            <h2 class="text-xl font-bold text-gray-800">{% if edit_cat %}Editar Categoría{% else %}Nueva Categoría{% endif %}</h2>
+            <form method="post" class="space-y-4 mt-4">
+              {% csrf_token %}
+              {{ categoria_form.as_p }}
+              <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded-md font-bold hover:bg-green-600 transition-colors">Guardar</button>
+              {% if edit_cat %}<a href="?section=categoria" class="ml-2 text-sm">Cancelar</a>{% endif %}
+            </form>
+          </div>
+        </div>
+      </div>
+    {% elif section == 'producto' %}
+      <h2 class="text-2xl font-bold text-gray-800">Productos</h2>
+      <div class="md:flex gap-4">
+        <div class="md:w-3/4 grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {% for p in productos %}
+          <div class="bg-white p-4 rounded-lg shadow">
+            <h3 class="font-semibold">{{ p.nombre }}</h3>
+            <p class="text-sm text-gray-500">{{ p.categoria }}</p>
+            <div class="mt-2 flex justify-end gap-2 text-xs">
+              <a href="?section=producto&edit_prod={{ p.id }}" onclick="return confirm('Editar este producto puede afectar variaciones asociadas. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
+              <form method="post" onsubmit="return confirm('Eliminar este producto eliminará sus variaciones. ¿Continuar?');">
+                {% csrf_token %}
+                <input type="hidden" name="delete_prod" value="{{ p.id }}">
+                <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
+              </form>
+            </div>
+          </div>
+          {% empty %}
+          <p class="text-gray-500 col-span-full">No hay productos registrados.</p>
+          {% endfor %}
+        </div>
+        <div class="md:w-1/4 mt-4 md:mt-0">
+          <div class="bg-white p-6 rounded-lg shadow">
+            <h2 class="text-xl font-bold text-gray-800">{% if edit_prod %}Editar Producto{% else %}Nuevo Producto{% endif %}</h2>
+            <form method="post" class="space-y-4 mt-4">
+              {% csrf_token %}
+              {{ producto_form.as_p }}
+              <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded-md font-bold hover:bg-green-600 transition-colors">Guardar</button>
+              {% if edit_prod %}<a href="?section=producto" class="ml-2 text-sm">Cancelar</a>{% endif %}
+            </form>
+          </div>
+        </div>
+      </div>
+    {% elif section == 'variacion' %}
+      <h2 class="text-2xl font-bold text-gray-800">Variaciones</h2>
+      <div class="md:flex gap-4">
+        <div class="md:w-3/4 grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {% for v in variaciones %}
+          <div class="bg-white p-4 rounded-lg shadow text-sm">
+            <h3 class="font-semibold">{{ v.producto }}</h3>
+            <p class="text-gray-500">${{ v.precio_base|floatformat:0 }}</p>
+            <p class="mt-1">{% for val in v.valores.all %}{{ val }}{% if not forloop.last %}, {% endif %}{% endfor %}</p>
+            <div class="mt-2 flex justify-end gap-2 text-xs">
+              <a href="?section=variacion&edit_var={{ v.id }}" onclick="return confirm('Editar esta variación puede afectar pedidos existentes. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
+              <form method="post" onsubmit="return confirm('Eliminar esta variación podría afectar pedidos. ¿Continuar?');">
+                {% csrf_token %}
+                <input type="hidden" name="delete_var" value="{{ v.id }}">
+                <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
+              </form>
+            </div>
+          </div>
+          {% empty %}
+          <p class="text-gray-500 col-span-full">No hay variaciones registradas.</p>
+          {% endfor %}
+        </div>
+        <div class="md:w-1/4 mt-4 md:mt-0">
+          <div class="bg-white p-6 rounded-lg shadow">
+            <h2 class="text-xl font-bold text-gray-800">{% if edit_var %}Editar Variación{% else %}Nueva Variación{% endif %}</h2>
+            <form method="post" class="space-y-4 mt-4">
+              {% csrf_token %}
+              {{ variacion_form.as_p }}
+              <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded-md font-bold hover:bg-green-600 transition-colors">Guardar</button>
+              {% if edit_var %}<a href="?section=variacion" class="ml-2 text-sm">Cancelar</a>{% endif %}
+            </form>
+          </div>
+        </div>
+      </div>
+    {% elif section == 'atributo' %}
+      <h2 class="text-2xl font-bold text-gray-800">Atributos</h2>
+      <div class="md:flex gap-4">
+        <div class="md:w-3/4 grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {% for a in atributos %}
+          <div class="bg-white p-4 rounded-lg shadow">
+            <h3 class="font-semibold">{{ a.nombre }}</h3>
+            <p class="text-sm text-gray-500">{{ a.tipo_producto.nombre }}</p>
+            <div class="mt-2 flex justify-end gap-2 text-xs">
+              <a href="?section=atributo&edit_atr={{ a.id }}" onclick="return confirm('Editar este atributo afectará valores asociados. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
+              <form method="post" onsubmit="return confirm('Eliminar este atributo eliminará sus valores. ¿Continuar?');">
+                {% csrf_token %}
+                <input type="hidden" name="delete_atr" value="{{ a.id }}">
+                <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
+              </form>
+            </div>
+          </div>
+          {% empty %}
+          <p class="text-gray-500 col-span-full">No hay atributos registrados.</p>
+          {% endfor %}
+        </div>
+        <div class="md:w-1/4 mt-4 md:mt-0">
+          <div class="bg-white p-6 rounded-lg shadow">
+            <h2 class="text-xl font-bold text-gray-800">{% if edit_atr %}Editar Atributo{% else %}Nuevo Atributo{% endif %}</h2>
+            <form method="post" class="space-y-4 mt-4">
+              {% csrf_token %}
+              {{ atributo_form.as_p }}
+              <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded-md font-bold hover:bg-green-600 transition-colors">Guardar</button>
+              {% if edit_atr %}<a href="?section=atributo" class="ml-2 text-sm">Cancelar</a>{% endif %}
+            </form>
+          </div>
+        </div>
+      </div>
+    {% elif section == 'valor' %}
+      <h2 class="text-2xl font-bold text-gray-800">Valores de Atributo</h2>
+      <div class="md:flex gap-4">
+        <div class="md:w-3/4 grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {% for v in valores %}
+          <div class="bg-white p-4 rounded-lg shadow text-sm">
+            <h3 class="font-semibold">{{ v.valor }}</h3>
+            <p class="text-gray-500">{{ v.atributo_def.nombre }}</p>
+            <div class="mt-2 flex justify-end gap-2 text-xs">
+              <a href="?section=valor&edit_val={{ v.id }}" onclick="return confirm('Editar este valor afectará variaciones que lo usan. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
+              <form method="post" onsubmit="return confirm('Eliminar este valor podría afectar variaciones. ¿Continuar?');">
+                {% csrf_token %}
+                <input type="hidden" name="delete_val" value="{{ v.id }}">
+                <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
+              </form>
+            </div>
+          </div>
+          {% empty %}
+          <p class="text-gray-500 col-span-full">No hay valores registrados.</p>
+          {% endfor %}
+        </div>
+        <div class="md:w-1/4 mt-4 md:mt-0">
+          <div class="bg-white p-6 rounded-lg shadow">
+            <h2 class="text-xl font-bold text-gray-800">{% if edit_val %}Editar Valor{% else %}Nuevo Valor{% endif %}</h2>
+            <form method="post" class="space-y-4 mt-4">
+              {% csrf_token %}
+              {{ valor_form.as_p }}
+              <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded-md font-bold hover:bg-green-600 transition-colors">Guardar</button>
+              {% if edit_val %}<a href="?section=valor" class="ml-2 text-sm">Cancelar</a>{% endif %}
+            </form>
+          </div>
+        </div>
+      </div>
+    {% elif section == 'cliente' %}
+      <h2 class="text-2xl font-bold text-gray-800">Clientes Registrados</h2>
+      <div class="overflow-x-auto bg-white rounded-lg shadow mb-4 mt-4">
+        <table class="min-w-full text-sm text-left text-gray-700">
+          <thead class="bg-gray-100 text-xs uppercase">
+            <tr><th class="px-6 py-3">ID</th><th class="px-6 py-3">Nombre</th><th class="px-6 py-3">Teléfono</th><th class="px-6 py-3">Dirección</th></tr>
+          </thead>
+          <tbody>
+            {% for c in clientes %}
+            <tr class="border-b hover:bg-gray-50"><td class="px-6 py-4">{{ c.id }}</td><td class="px-6 py-4">{{ c.nombre }}</td><td class="px-6 py-4">{{ c.telefono }}</td><td class="px-6 py-4">{{ c.direccion }}, {{ c.ciudad }}</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% endif %}
   </div>
   {% endif %}
 </div>
@@ -134,8 +343,27 @@
 {% block extra_scripts %}
 <script>
     document.addEventListener('DOMContentLoaded', () => {
-        if (document.querySelector('#id_var-valores')) {
-            new TomSelect('#id_var-valores', { plugins: ['remove_button'] });
+        const valoresSel = document.querySelector('#id_var-valores');
+        const productoSel = document.querySelector('#id_var-producto');
+        let tom;
+        if (valoresSel) {
+            tom = new TomSelect(valoresSel, { plugins: ['remove_button'] });
+        }
+        function cargarValores(prodId) {
+            if (!tom || !prodId) { if(tom) tom.clearOptions(); return; }
+            fetch('{% url "catalogo:valores_por_producto" %}?producto_id=' + prodId)
+                .then(r => r.json())
+                .then(data => {
+                    tom.clearOptions();
+                    data.valores.forEach(v => tom.addOption({value: v.id, text: v.label}));
+                    tom.refreshOptions(false);
+                });
+        }
+        if (productoSel) {
+            productoSel.addEventListener('change', e => cargarValores(e.target.value));
+            if (productoSel.value) {
+                cargarValores(productoSel.value);
+            }
         }
         document.querySelectorAll('.toggle-items').forEach(btn => {
             btn.addEventListener('click', (event) => {

--- a/catalogo/urls.py
+++ b/catalogo/urls.py
@@ -17,4 +17,5 @@ urlpatterns = [
     path('admin/pedido/<int:pedido_id>/estado/', views.actualizar_estado_pedido, name='actualizar_estado_pedido'),
     # --- NUEVA RUTA PARA EL PDF ---
     path('admin/pedido/<int:pedido_id>/pdf/', views.generar_pedido_pdf, name='generar_pedido_pdf'),
+    path('admin/valores-producto/', views.valores_por_producto, name='valores_por_producto'),
 ]

--- a/catalogo/views.py
+++ b/catalogo/views.py
@@ -15,7 +15,14 @@ from xhtml2pdf import pisa
 import io
 # ---------------------------------------------
 
-from .forms import TipoProductoForm, CategoriaForm, ProductoForm, VariacionProductoForm
+from .forms import (
+    TipoProductoForm,
+    CategoriaForm,
+    ProductoForm,
+    VariacionProductoForm,
+    AtributoDefForm,
+    ValorAtributoForm,
+)
 from .models import (
     Cliente, Administrador, TipoProducto, Categoria, Producto,
     AtributoDef, ValorAtributo, VariacionProducto, Promo,
@@ -250,32 +257,78 @@ def pedido_create(request):
 def admin_dashboard(request):
     """Panel de administración del catálogo, protegido por login de staff."""
     section = request.GET.get('section', 'pedidos')
-    tipo_form = TipoProductoForm(prefix='tipo')
-    categoria_form = CategoriaForm(prefix='cat')
-    producto_form = ProductoForm(prefix='prod')
-    variacion_form = VariacionProductoForm(prefix='var')
+    edit_tipo = request.GET.get('edit_tipo')
+    edit_cat = request.GET.get('edit_cat')
+    edit_prod = request.GET.get('edit_prod')
+    edit_var = request.GET.get('edit_var')
+    edit_atr = request.GET.get('edit_atr')
+    edit_val = request.GET.get('edit_val')
+
+    tipo_form = TipoProductoForm(prefix='tipo', instance=TipoProducto.objects.get(id=edit_tipo) if edit_tipo else None)
+    categoria_form = CategoriaForm(prefix='cat', instance=Categoria.objects.get(id=edit_cat) if edit_cat else None)
+    producto_form = ProductoForm(prefix='prod', instance=Producto.objects.get(id=edit_prod) if edit_prod else None)
+    variacion_form = VariacionProductoForm(prefix='var', instance=VariacionProducto.objects.get(id=edit_var) if edit_var else None)
+    atributo_form = AtributoDefForm(prefix='atr', instance=AtributoDef.objects.get(id=edit_atr) if edit_atr else None)
+    valor_form = ValorAtributoForm(prefix='val', instance=ValorAtributo.objects.get(id=edit_val) if edit_val else None)
 
     if request.method == 'POST':
+        # eliminaciones
+        if 'delete_tipo' in request.POST:
+            TipoProducto.objects.filter(id=request.POST['delete_tipo']).delete()
+            return redirect(f"{reverse('catalogo:admin_dashboard')}?section=tipo")
+        if 'delete_cat' in request.POST:
+            Categoria.objects.filter(id=request.POST['delete_cat']).delete()
+            return redirect(f"{reverse('catalogo:admin_dashboard')}?section=categoria")
+        if 'delete_prod' in request.POST:
+            Producto.objects.filter(id=request.POST['delete_prod']).delete()
+            return redirect(f"{reverse('catalogo:admin_dashboard')}?section=producto")
+        if 'delete_var' in request.POST:
+            VariacionProducto.objects.filter(id=request.POST['delete_var']).delete()
+            return redirect(f"{reverse('catalogo:admin_dashboard')}?section=variacion")
+        if 'delete_atr' in request.POST:
+            AtributoDef.objects.filter(id=request.POST['delete_atr']).delete()
+            return redirect(f"{reverse('catalogo:admin_dashboard')}?section=atributo")
+        if 'delete_val' in request.POST:
+            ValorAtributo.objects.filter(id=request.POST['delete_val']).delete()
+            return redirect(f"{reverse('catalogo:admin_dashboard')}?section=valor")
+
+        # creaciones/ediciones
         if 'tipo-nombre' in request.POST:
-            tipo_form = TipoProductoForm(request.POST, prefix='tipo')
+            instance = TipoProducto.objects.get(id=edit_tipo) if edit_tipo else None
+            tipo_form = TipoProductoForm(request.POST, prefix='tipo', instance=instance)
             if tipo_form.is_valid():
                 tipo_form.save()
                 return redirect(f"{reverse('catalogo:admin_dashboard')}?section=tipo")
         if 'cat-nombre' in request.POST:
-            categoria_form = CategoriaForm(request.POST, prefix='cat')
+            instance = Categoria.objects.get(id=edit_cat) if edit_cat else None
+            categoria_form = CategoriaForm(request.POST, prefix='cat', instance=instance)
             if categoria_form.is_valid():
                 categoria_form.save()
                 return redirect(f"{reverse('catalogo:admin_dashboard')}?section=categoria")
         if 'prod-nombre' in request.POST:
-            producto_form = ProductoForm(request.POST, prefix='prod')
+            instance = Producto.objects.get(id=edit_prod) if edit_prod else None
+            producto_form = ProductoForm(request.POST, prefix='prod', instance=instance)
             if producto_form.is_valid():
                 producto_form.save()
                 return redirect(f"{reverse('catalogo:admin_dashboard')}?section=producto")
         if 'var-precio_base' in request.POST:
-            variacion_form = VariacionProductoForm(request.POST, prefix='var')
+            instance = VariacionProducto.objects.get(id=edit_var) if edit_var else None
+            variacion_form = VariacionProductoForm(request.POST, prefix='var', instance=instance)
             if variacion_form.is_valid():
                 variacion_form.save()
                 return redirect(f"{reverse('catalogo:admin_dashboard')}?section=variacion")
+        if 'atr-nombre' in request.POST:
+            instance = AtributoDef.objects.get(id=edit_atr) if edit_atr else None
+            atributo_form = AtributoDefForm(request.POST, prefix='atr', instance=instance)
+            if atributo_form.is_valid():
+                atributo_form.save()
+                return redirect(f"{reverse('catalogo:admin_dashboard')}?section=atributo")
+        if 'val-valor' in request.POST:
+            instance = ValorAtributo.objects.get(id=edit_val) if edit_val else None
+            valor_form = ValorAtributoForm(request.POST, prefix='val', instance=instance)
+            if valor_form.is_valid():
+                valor_form.save()
+                return redirect(f"{reverse('catalogo:admin_dashboard')}?section=valor")
 
     pedidos = (
         Pedido.objects.select_related('cliente')
@@ -287,14 +340,32 @@ def admin_dashboard(request):
         .order_by('-fecha')
     )
     clientes = Cliente.objects.all().order_by('nombre')
-    
+    tipos = TipoProducto.objects.all().order_by('nombre')
+    categorias = Categoria.objects.select_related('tipo_producto').order_by('tipo_producto__nombre', 'nombre')
+    productos = Producto.objects.select_related('categoria__tipo_producto').order_by('categoria__nombre', 'nombre')
+    variaciones = (
+        VariacionProducto.objects.select_related('producto__categoria__tipo_producto')
+        .prefetch_related('valores__atributo_def')
+        .all()
+    )
+    atributos = AtributoDef.objects.select_related('tipo_producto').order_by('tipo_producto__nombre', 'nombre')
+    valores = ValorAtributo.objects.select_related('atributo_def__tipo_producto').order_by('atributo_def__nombre', 'valor')
+
     return render(request, 'catalogo/admin_dashboard.html', {
         'pedidos': pedidos,
         'tipo_form': tipo_form,
         'categoria_form': categoria_form,
         'producto_form': producto_form,
         'variacion_form': variacion_form,
+        'atributo_form': atributo_form,
+        'valor_form': valor_form,
         'clientes': clientes,
+        'tipos': tipos,
+        'categorias': categorias,
+        'productos': productos,
+        'variaciones': variaciones,
+        'atributos': atributos,
+        'valores': valores,
         'estados': EstadoPedido.choices,
         'section': section,
     })
@@ -347,3 +418,30 @@ def generar_pedido_pdf(request, pedido_id):
         return response
     
     return HttpResponse("Error al generar el PDF", status=500)
+
+
+@staff_member_required
+@require_http_methods(["GET"])
+def valores_por_producto(request):
+    """Devuelve los valores de atributo asociados al tipo del producto."""
+    producto_id = request.GET.get('producto_id')
+    if not producto_id:
+        return JsonResponse({'error': 'producto_id requerido'}, status=400)
+
+    try:
+        producto = Producto.objects.select_related('categoria__tipo_producto').get(id=producto_id)
+    except Producto.DoesNotExist:
+        return JsonResponse({'error': 'Producto no encontrado'}, status=404)
+
+    valores = ValorAtributo.objects.filter(
+        atributo_def__tipo_producto=producto.categoria.tipo_producto
+    ).values('id', 'valor', 'atributo_def__nombre')
+
+    data = [
+        {
+            'id': v['id'],
+            'label': f"{v['atributo_def__nombre']}: {v['valor']}"
+        }
+        for v in valores
+    ]
+    return JsonResponse({'valores': data})


### PR DESCRIPTION
## Summary
- add forms for attribute definitions and values
- restructure admin dashboard into card layout with edit/delete buttons
- allow editing and deleting of all catalog items with confirmation prompts
- list and manage attribute definitions and values
- widen the admin list column for better visibility

## Testing
- `python3 -m pip install -q -r requirements.txt`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6865f7947e14832c9918bd427edc4570