### PR TITLE
Adjust catalog admin UI

### DIFF
--- a/catalogo/models.py
+++ b/catalogo/models.py
@@ -60,8 +60,8 @@ class Producto(models.Model):
         ordering = ["nombre"]
 
     def __str__(self):
-        # Mostrar la categoría para una mejor referencia en el admin
-        return f"{self.categoria.nombre} - {self.nombre}"
+        """Mostrar solo la referencia junto con la categoría."""
+        return f"{self.categoria.nombre} - {self.referencia}"
 
 
 class AtributoDef(models.Model):
@@ -111,9 +111,9 @@ class VariacionProducto(models.Model):
     valores = models.ManyToManyField(ValorAtributo, related_name="variaciones")
 
     def __str__(self):
-        # Genera una descripción de la variación para el admin
+        """Descripción de la variación usando referencia y categoría."""
         valores_str = ", ".join([v.valor for v in self.valores.all()])
-        return f"{self.producto.nombre} ({valores_str})"
+        return f"{self.producto.categoria.nombre}: {self.producto.referencia} ({valores_str})"
 
 
 class Carrito(models.Model):

--- a/catalogo/static/catalogo/script.js
+++ b/catalogo/static/catalogo/script.js
@@ -77,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!producto) return;
         state.modalSelection = { productoId, variation: null, quantity: 1, selectedAtributos: {} };
         modalProductImg.src = producto.foto_url;
-        modalProductName.textContent = producto.nombre;
+        modalProductName.textContent = producto.referencia;
         const dynamicContent = modalProductAttributesContainer.querySelector('#dynamic-attributes');
         if (dynamicContent) dynamicContent.remove();
         const variaciones = DATA.variacionesProducto.filter(v => v.productoId === productoId);
@@ -164,7 +164,7 @@ document.addEventListener('DOMContentLoaded', () => {
             state.cart.items.push({
                 variationId: variation.id,
                 productoId: producto.id,
-                name: producto.nombre,
+                name: producto.referencia,
                 image: producto.foto_url,
                 priceBase: variation.precioBase,
                 quantity,
@@ -508,7 +508,7 @@ document.addEventListener('DOMContentLoaded', () => {
         productsTitle.textContent = cat ? cat.nombre : '';
         productsGrid.innerHTML = DATA.productos
             .filter(p => p.categoriaId === categoriaId)
-            .map(prod => `<div class="product-card cursor-pointer" data-product-id="${prod.id}"><img src="${prod.foto_url}" alt="${prod.nombre}" class="w-full h-48 object-cover"><div class="p-3"><h4 class="font-bold text-center">${prod.nombre}</h4></div></div>`)
+            .map(prod => `<div class="product-card cursor-pointer" data-product-id="${prod.id}"><img src="${prod.foto_url}" alt="${prod.referencia}" class="w-full h-48 object-cover"><div class="p-3"><h4 class="font-bold text-center">${prod.referencia}</h4></div></div>`)
             .join('');
         showPage('products-page');
     };

--- a/catalogo/templates/catalogo/admin_dashboard.html
+++ b/catalogo/templates/catalogo/admin_dashboard.html
@@ -13,12 +13,12 @@
       </a>
     </li>
     <!-- ... otros nav links ... -->
-    <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=tipo" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'tipo' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Tipos</a></li>
-    <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=categoria" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'categoria' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Categorías</a></li>
     <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=producto" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'producto' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Productos</a></li>
-    <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=variacion" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'variacion' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Variaciones</a></li>
     <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=atributo" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'atributo' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Atributos</a></li>
     <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=valor" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'valor' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Valores</a></li>
+    <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=variacion" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'variacion' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Variaciones</a></li>
+    <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=tipo" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'tipo' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Tipos</a></li>
+    <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=categoria" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'categoria' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Categorías</a></li>
     <li class="mr-2"><a href="{% url 'catalogo:admin_dashboard' %}?section=cliente" class="inline-flex p-4 rounded-t-lg border-b-2 {% if section == 'cliente' %}text-blue-600 border-blue-600 active{% else %}border-transparent hover:text-gray-600 hover:border-gray-300{% endif %}">Clientes</a></li>
   </ul>
 </nav>
@@ -122,28 +122,33 @@
   </div>
   {% else %}
   <div class="space-y-8">
-    {% if section == 'tipo' %}
+{% if section == 'tipo' %}
       <h2 class="text-2xl font-bold text-gray-800">Tipos de Producto</h2>
 
         <div class="md:flex gap-4">
-        <div class="md:w-3/4 grid grid-cols-1 sm:grid-cols-2 gap-4">
-
-
-          {% for t in tipos %}
-          <div class="bg-white p-4 rounded-lg shadow">
-            <h3 class="font-semibold">{{ t.nombre }}</h3>
-            <div class="mt-2 flex justify-end gap-2 text-xs">
-              <a href="?section=tipo&edit_tipo={{ t.id }}" onclick="return confirm('Editar este tipo puede afectar categorías y productos asociados. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
-              <form method="post" onsubmit="return confirm('Eliminar este tipo eliminará sus categorías y productos asociados. ¿Continuar?');">
-                {% csrf_token %}
-                <input type="hidden" name="delete_tipo" value="{{ t.id }}">
-                <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
-              </form>
-            </div>
-          </div>
-          {% empty %}
-          <p class="text-gray-500 col-span-full">No hay tipos registrados.</p>
-          {% endfor %}
+        <div class="md:w-3/4 overflow-x-auto">
+          <table class="min-w-full text-sm text-left text-gray-700">
+            <thead class="bg-gray-100 text-xs uppercase">
+              <tr><th class="px-6 py-3">Nombre</th><th class="px-6 py-3">Acciones</th></tr>
+            </thead>
+            <tbody>
+            {% for t in tipos %}
+              <tr class="border-b hover:bg-gray-50">
+                <td class="px-6 py-4">{{ t.nombre }}</td>
+                <td class="px-6 py-4">
+                  <a href="?section=tipo&edit_tipo={{ t.id }}" onclick="return confirm('Editar este tipo puede afectar categorías y productos asociados. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
+                  <form method="post" class="inline" onsubmit="return confirm('Eliminar este tipo eliminará sus categorías y productos asociados. ¿Continuar?');">
+                    {% csrf_token %}
+                    <input type="hidden" name="delete_tipo" value="{{ t.id }}">
+                    <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
+                  </form>
+                </td>
+              </tr>
+            {% empty %}
+              <tr><td colspan="2" class="text-center py-4 text-gray-500">No hay tipos registrados.</td></tr>
+            {% endfor %}
+            </tbody>
+          </table>
         </div>
 
         <div class="md:w-1/4 mt-4 md:mt-0">
@@ -159,28 +164,34 @@
           </div>
         </div>
       </div>
-    {% elif section == 'categoria' %}
+{% elif section == 'categoria' %}
       <h2 class="text-2xl font-bold text-gray-800">Categorías</h2>
       <div class="md:flex gap-4">
 
-        <div class="md:w-3/4 grid grid-cols-1 sm:grid-cols-2 gap-4">
-
-          {% for c in categorias %}
-          <div class="bg-white p-4 rounded-lg shadow">
-            <h3 class="font-semibold">{{ c.nombre }}</h3>
-            <p class="text-sm text-gray-500">{{ c.tipo_producto.nombre }}</p>
-            <div class="mt-2 flex justify-end gap-2 text-xs">
-              <a href="?section=categoria&edit_cat={{ c.id }}" onclick="return confirm('Editar esta categoría puede afectar productos asociados. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
-              <form method="post" onsubmit="return confirm('Eliminar esta categoría eliminará los productos asociados. ¿Continuar?');">
-                {% csrf_token %}
-                <input type="hidden" name="delete_cat" value="{{ c.id }}">
-                <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
-              </form>
-            </div>
-          </div>
-          {% empty %}
-          <p class="text-gray-500 col-span-full">No hay categorías registradas.</p>
-          {% endfor %}
+        <div class="md:w-3/4 overflow-x-auto">
+          <table class="min-w-full text-sm text-left text-gray-700">
+            <thead class="bg-gray-100 text-xs uppercase">
+              <tr><th class="px-6 py-3">Nombre</th><th class="px-6 py-3">Tipo</th><th class="px-6 py-3">Acciones</th></tr>
+            </thead>
+            <tbody>
+              {% for c in categorias %}
+              <tr class="border-b hover:bg-gray-50">
+                <td class="px-6 py-4">{{ c.nombre }}</td>
+                <td class="px-6 py-4">{{ c.tipo_producto.nombre }}</td>
+                <td class="px-6 py-4">
+                  <a href="?section=categoria&edit_cat={{ c.id }}" onclick="return confirm('Editar esta categoría puede afectar productos asociados. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
+                  <form method="post" class="inline" onsubmit="return confirm('Eliminar esta categoría eliminará los productos asociados. ¿Continuar?');">
+                    {% csrf_token %}
+                    <input type="hidden" name="delete_cat" value="{{ c.id }}">
+                    <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
+                  </form>
+                </td>
+              </tr>
+              {% empty %}
+              <tr><td colspan="3" class="text-center py-4 text-gray-500">No hay categorías registradas.</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
         </div>
 
         <div class="md:w-1/4 mt-4 md:mt-0">
@@ -200,24 +211,30 @@
       <h2 class="text-2xl font-bold text-gray-800">Productos</h2>
       <div class="md:flex gap-4">
 
-        <div class="md:w-3/4 grid grid-cols-1 sm:grid-cols-2 gap-4">
-
-          {% for p in productos %}
-          <div class="bg-white p-4 rounded-lg shadow">
-            <h3 class="font-semibold">{{ p.nombre }}</h3>
-            <p class="text-sm text-gray-500">{{ p.categoria }}</p>
-            <div class="mt-2 flex justify-end gap-2 text-xs">
-              <a href="?section=producto&edit_prod={{ p.id }}" onclick="return confirm('Editar este producto puede afectar variaciones asociadas. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
-              <form method="post" onsubmit="return confirm('Eliminar este producto eliminará sus variaciones. ¿Continuar?');">
-                {% csrf_token %}
-                <input type="hidden" name="delete_prod" value="{{ p.id }}">
-                <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
-              </form>
-            </div>
-          </div>
-          {% empty %}
-          <p class="text-gray-500 col-span-full">No hay productos registrados.</p>
-          {% endfor %}
+        <div class="md:w-3/4 overflow-x-auto">
+          <table class="min-w-full text-sm text-left text-gray-700">
+            <thead class="bg-gray-100 text-xs uppercase">
+              <tr><th class="px-6 py-3">Referencia</th><th class="px-6 py-3">Categoría</th><th class="px-6 py-3">Acciones</th></tr>
+            </thead>
+            <tbody>
+              {% for p in productos %}
+              <tr class="border-b hover:bg-gray-50">
+                <td class="px-6 py-4">{{ p.referencia }}</td>
+                <td class="px-6 py-4">{{ p.categoria }}</td>
+                <td class="px-6 py-4">
+                  <a href="?section=producto&edit_prod={{ p.id }}" onclick="return confirm('Editar este producto puede afectar variaciones asociadas. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
+                  <form method="post" class="inline" onsubmit="return confirm('Eliminar este producto eliminará sus variaciones. ¿Continuar?');">
+                    {% csrf_token %}
+                    <input type="hidden" name="delete_prod" value="{{ p.id }}">
+                    <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
+                  </form>
+                </td>
+              </tr>
+              {% empty %}
+              <tr><td colspan="3" class="text-center py-4 text-gray-500">No hay productos registrados.</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
         </div>
 
         <div class="md:w-1/4 mt-4 md:mt-0">
@@ -233,29 +250,35 @@
           </div>
         </div>
       </div>
-    {% elif section == 'variacion' %}
+{% elif section == 'variacion' %}
       <h2 class="text-2xl font-bold text-gray-800">Variaciones</h2>
       <div class="md:flex gap-4">
 
-        <div class="md:w-3/4 grid grid-cols-1 sm:grid-cols-2 gap-4">
-
-          {% for v in variaciones %}
-          <div class="bg-white p-4 rounded-lg shadow text-sm">
-            <h3 class="font-semibold">{{ v.producto }}</h3>
-            <p class="text-gray-500">${{ v.precio_base|floatformat:0 }}</p>
-            <p class="mt-1">{% for val in v.valores.all %}{{ val }}{% if not forloop.last %}, {% endif %}{% endfor %}</p>
-            <div class="mt-2 flex justify-end gap-2 text-xs">
-              <a href="?section=variacion&edit_var={{ v.id }}" onclick="return confirm('Editar esta variación puede afectar pedidos existentes. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
-              <form method="post" onsubmit="return confirm('Eliminar esta variación podría afectar pedidos. ¿Continuar?');">
-                {% csrf_token %}
-                <input type="hidden" name="delete_var" value="{{ v.id }}">
-                <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
-              </form>
-            </div>
-          </div>
-          {% empty %}
-          <p class="text-gray-500 col-span-full">No hay variaciones registradas.</p>
-          {% endfor %}
+        <div class="md:w-3/4 overflow-x-auto">
+          <table class="min-w-full text-sm text-left text-gray-700">
+            <thead class="bg-gray-100 text-xs uppercase">
+              <tr><th class="px-6 py-3">Producto</th><th class="px-6 py-3">Precio</th><th class="px-6 py-3">Valores</th><th class="px-6 py-3">Acciones</th></tr>
+            </thead>
+            <tbody>
+              {% for v in variaciones %}
+              <tr class="border-b hover:bg-gray-50 text-sm">
+                <td class="px-6 py-4">{{ v.producto }}</td>
+                <td class="px-6 py-4">${{ v.precio_base|floatformat:0 }}</td>
+                <td class="px-6 py-4">{% for val in v.valores.all %}{{ val }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
+                <td class="px-6 py-4">
+                  <a href="?section=variacion&edit_var={{ v.id }}" onclick="return confirm('Editar esta variación puede afectar pedidos existentes. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
+                  <form method="post" class="inline" onsubmit="return confirm('Eliminar esta variación podría afectar pedidos. ¿Continuar?');">
+                    {% csrf_token %}
+                    <input type="hidden" name="delete_var" value="{{ v.id }}">
+                    <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
+                  </form>
+                </td>
+              </tr>
+              {% empty %}
+              <tr><td colspan="4" class="text-center py-4 text-gray-500">No hay variaciones registradas.</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
         </div>
 
         <div class="md:w-1/4 mt-4 md:mt-0">
@@ -271,28 +294,34 @@
           </div>
         </div>
       </div>
-    {% elif section == 'atributo' %}
+{% elif section == 'atributo' %}
       <h2 class="text-2xl font-bold text-gray-800">Atributos</h2>
       <div class="md:flex gap-4">
 
-        <div class="md:w-3/4 grid grid-cols-1 sm:grid-cols-2 gap-4">
-
-          {% for a in atributos %}
-          <div class="bg-white p-4 rounded-lg shadow">
-            <h3 class="font-semibold">{{ a.nombre }}</h3>
-            <p class="text-sm text-gray-500">{{ a.tipo_producto.nombre }}</p>
-            <div class="mt-2 flex justify-end gap-2 text-xs">
-              <a href="?section=atributo&edit_atr={{ a.id }}" onclick="return confirm('Editar este atributo afectará valores asociados. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
-              <form method="post" onsubmit="return confirm('Eliminar este atributo eliminará sus valores. ¿Continuar?');">
-                {% csrf_token %}
-                <input type="hidden" name="delete_atr" value="{{ a.id }}">
-                <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
-              </form>
-            </div>
-          </div>
-          {% empty %}
-          <p class="text-gray-500 col-span-full">No hay atributos registrados.</p>
-          {% endfor %}
+        <div class="md:w-3/4 overflow-x-auto">
+          <table class="min-w-full text-sm text-left text-gray-700">
+            <thead class="bg-gray-100 text-xs uppercase">
+              <tr><th class="px-6 py-3">Nombre</th><th class="px-6 py-3">Tipo</th><th class="px-6 py-3">Acciones</th></tr>
+            </thead>
+            <tbody>
+              {% for a in atributos %}
+              <tr class="border-b hover:bg-gray-50">
+                <td class="px-6 py-4">{{ a.nombre }}</td>
+                <td class="px-6 py-4">{{ a.tipo_producto.nombre }}</td>
+                <td class="px-6 py-4">
+                  <a href="?section=atributo&edit_atr={{ a.id }}" onclick="return confirm('Editar este atributo afectará valores asociados. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
+                  <form method="post" class="inline" onsubmit="return confirm('Eliminar este atributo eliminará sus valores. ¿Continuar?');">
+                    {% csrf_token %}
+                    <input type="hidden" name="delete_atr" value="{{ a.id }}">
+                    <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
+                  </form>
+                </td>
+              </tr>
+              {% empty %}
+              <tr><td colspan="3" class="text-center py-4 text-gray-500">No hay atributos registrados.</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
         </div>
 
         <div class="md:w-1/4 mt-4 md:mt-0">
@@ -308,28 +337,34 @@
           </div>
         </div>
       </div>
-    {% elif section == 'valor' %}
+{% elif section == 'valor' %}
       <h2 class="text-2xl font-bold text-gray-800">Valores de Atributo</h2>
       <div class="md:flex gap-4">
 
-        <div class="md:w-3/4 grid grid-cols-1 sm:grid-cols-2 gap-4">
-
-          {% for v in valores %}
-          <div class="bg-white p-4 rounded-lg shadow text-sm">
-            <h3 class="font-semibold">{{ v.valor }}</h3>
-            <p class="text-gray-500">{{ v.atributo_def.nombre }}</p>
-            <div class="mt-2 flex justify-end gap-2 text-xs">
-              <a href="?section=valor&edit_val={{ v.id }}" onclick="return confirm('Editar este valor afectará variaciones que lo usan. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
-              <form method="post" onsubmit="return confirm('Eliminar este valor podría afectar variaciones. ¿Continuar?');">
-                {% csrf_token %}
-                <input type="hidden" name="delete_val" value="{{ v.id }}">
-                <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
-              </form>
-            </div>
-          </div>
-          {% empty %}
-          <p class="text-gray-500 col-span-full">No hay valores registrados.</p>
-          {% endfor %}
+        <div class="md:w-3/4 overflow-x-auto">
+          <table class="min-w-full text-sm text-left text-gray-700">
+            <thead class="bg-gray-100 text-xs uppercase">
+              <tr><th class="px-6 py-3">Valor</th><th class="px-6 py-3">Atributo</th><th class="px-6 py-3">Acciones</th></tr>
+            </thead>
+            <tbody>
+              {% for v in valores %}
+              <tr class="border-b hover:bg-gray-50 text-sm">
+                <td class="px-6 py-4">{{ v.valor }}</td>
+                <td class="px-6 py-4">{{ v.atributo_def.nombre }}</td>
+                <td class="px-6 py-4">
+                  <a href="?section=valor&edit_val={{ v.id }}" onclick="return confirm('Editar este valor afectará variaciones que lo usan. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
+                  <form method="post" class="inline" onsubmit="return confirm('Eliminar este valor podría afectar variaciones. ¿Continuar?');">
+                    {% csrf_token %}
+                    <input type="hidden" name="delete_val" value="{{ v.id }}">
+                    <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
+                  </form>
+                </td>
+              </tr>
+              {% empty %}
+              <tr><td colspan="3" class="text-center py-4 text-gray-500">No hay valores registrados.</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
         </div>
 
         <div class="md:w-1/4 mt-4 md:mt-0">

--- a/catalogo/views.py
+++ b/catalogo/views.py
@@ -59,6 +59,7 @@ def build_catalog_data():
                 'id': p.id,
                 'categoriaId': p.categoria_id,
                 'nombre': p.nombre,
+                'referencia': p.referencia,
                 'foto_url': p.foto_url,
             }
             for p in Producto.objects.all()


### PR DESCRIPTION
## Summary
- show product reference instead of name
- output product reference in build data
- switch admin catalog lists to use tables
- reorder admin navigation

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686743b9ba00832c91d94261ea402d54