### PR TITLE
Show days since task received

### DIFF
--- a/gestor_tareas/models.py
+++ b/gestor_tareas/models.py
@@ -100,9 +100,14 @@ class Tarea(models.Model):
     )
     
     is_visible = models.BooleanField(
-        default=True, 
+        default=True,
         help_text="Indica si la tarea es visible en la lista principal. Desmarcar para archivar."
     )
+
+    @property
+    def dias_desde_recibido(self) -> int:
+        """Cantidad de días transcurridos desde ``fecha_recibido``."""
+        return (timezone.now().date() - self.fecha_recibido).days
 
     def save(self, *args, **kwargs):
         """

--- a/gestor_tareas/templates/gestor_tareas/lista_tareas.html
+++ b/gestor_tareas/templates/gestor_tareas/lista_tareas.html
@@ -24,12 +24,12 @@
                 <thead class="text-xs text-slate-400 uppercase">
                     <tr>
                         <th class="px-4 py-3">Orden</th>
+                        <th class="px-4 py-3">Recibido</th>
                         <th class="px-4 py-3">Cliente / Teléfono</th>
                         <th class="px-4 py-3">Tipo</th>
                         <th class="px-4 py-3">Descripción</th>
                         <th class="px-4 py-3">Estado</th>
                         <th class="px-4 py-3">Prioridad</th>
-                        <th class="px-4 py-3">Recibido</th>
                         <th class="px-4 py-3">Acciones</th>
                     </tr>
                 </thead>
@@ -38,6 +38,8 @@
                     <tr id="tarea-row-{{ tarea.id }}" class="hover:bg-slate-700/50 transition-colors duration-200 {% if tarea.estado == 'Completado' %}completed-row{% endif %}">
 
                         <td class="px-4 py-3 text-xl font-bold text-white">{{ tarea.orden|default:0 }}</td>
+
+                        <td class="px-4 py-3">{{ tarea.dias_desde_recibido }}</td>
 
                         <td class="px-4 py-3 font-medium text-white">
                             {{ tarea.cliente }}
@@ -76,8 +78,6 @@
                             {{ tarea.prioridad }}
                           </span>
                         </td>
-                        <td class="px-4 py-3">{{ tarea.fecha_recibido|date:"Y-m-d" }}</td>
-                        
                         <td class="px-4 py-3 whitespace-nowrap">
                             <a href="{% url 'gestor_tareas:editar_tarea' tarea.id %}" class="text-yellow-400 hover:text-yellow-300 mr-3 font-medium">Editar</a>
                             <button onclick="ocultarTarea({{ tarea.id }})" class="text-red-500 hover:text-red-400 font-medium">Ocultar</button>


### PR DESCRIPTION
## Summary
- add `dias_desde_recibido` property in `Tarea`
- display "Recibido" column after "Orden" showing days since reception

## Testing
- `python manage.py test` *(fails: FileNotFoundError for credentials)*

------
https://chatgpt.com/codex/tasks/task_e_6871c7736ca4832c8f1fc744d7f762fb