### PR TITLE
Improve variation management UI

### DIFF
--- a/catalogo/forms.py
+++ b/catalogo/forms.py
@@ -49,6 +49,12 @@ class AtributoDefForm(BaseStyledForm):
 
 class ValorAtributoForm(BaseStyledForm):
 
+    def __init__(self, *args, **kwargs):
+        """Show product type in attribute choices."""
+        super().__init__(*args, **kwargs)
+        field = self.fields["atributo_def"]
+        field.label_from_instance = lambda obj: f"{obj.tipo_producto.nombre} - {obj.nombre}"
+
     class Meta:
         model = ValorAtributo
         fields = ['atributo_def', 'valor', 'display']
@@ -72,6 +78,8 @@ class VariacionProductoForm(BaseStyledForm):
             producto_id = self.data.get(field_name)
         elif self.instance.pk:
             producto_id = self.instance.producto_id
+        elif self.initial.get('producto'):
+            producto_id = self.initial.get('producto')
 
         if producto_id:
             try:

--- a/catalogo/templates/catalogo/admin_dashboard.html
+++ b/catalogo/templates/catalogo/admin_dashboard.html
@@ -271,46 +271,80 @@
       </div>
 {% elif section == 'variacion' %}
       <h2 class="text-2xl font-bold text-gray-800">Variaciones</h2>
+      <div class="mb-4 md:w-1/2">
+        <input id="buscar-producto" type="text" placeholder="Buscar producto..." class="border rounded p-2 w-full">
+      </div>
       <div class="md:flex gap-4">
 
-        <div class="md:w-3/4 space-y-4">
-          {% regroup variaciones by producto as vars_por_prod %}
-          {% for g in vars_por_prod %}
-          <div class="border rounded">
-            <div class="bg-gray-50 flex justify-between items-center px-4 py-2">
-              <div class="flex items-center gap-2">
-                <img src="{{ g.grouper.foto_url }}" alt="{{ g.grouper.referencia }}" class="h-8 w-8 object-cover">
-                <span class="font-semibold">{{ g.grouper.referencia }}</span>
-              </div>
-              <button class="accordion-toggle text-sm text-blue-600" data-target="vars-{{ forloop.counter }}">Ver</button>
-            </div>
-            <div id="vars-{{ forloop.counter }}" class="hidden overflow-x-auto">
-              <table class="min-w-full text-sm text-left text-gray-700">
-                <thead class="bg-gray-100 text-xs uppercase">
-                  <tr><th class="px-6 py-3">Precio</th><th class="px-6 py-3">Valores</th><th class="px-6 py-3">Acciones</th></tr>
-                </thead>
-                <tbody>
-                  {% for v in g.list %}
-                  <tr class="border-b hover:bg-gray-50 text-sm">
-                    <td class="px-6 py-4">${{ v.precio_base|floatformat:0 }}</td>
-                    <td class="px-6 py-4">{% for val in v.valores.all %}{{ val }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
-                    <td class="px-6 py-4">
-                      <a href="?section=variacion&edit_var={{ v.id }}" onclick="return confirm('Editar esta variación puede afectar pedidos existentes. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
-                      <form method="post" class="inline" onsubmit="return confirm('Eliminar esta variación podría afectar pedidos. ¿Continuar?');">
-                        {% csrf_token %}
-                        <input type="hidden" name="delete_var" value="{{ v.id }}">
-                        <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
-                      </form>
-                    </td>
-                  </tr>
-                  {% endfor %}
-                </tbody>
-              </table>
-            </div>
+        <div class="md:w-3/4 space-y-8">
+          <div class="overflow-x-auto">
+            <h3 class="font-semibold mb-2">Productos con Variaciones</h3>
+            <table id="con-var" class="min-w-full text-sm text-left text-gray-700">
+              <thead class="bg-gray-100 text-xs uppercase">
+                <tr><th class="px-6 py-3">Foto</th><th class="px-6 py-3">Referencia</th><th class="px-6 py-3">Acciones</th></tr>
+              </thead>
+              <tbody>
+                {% for p in productos_con_vars %}
+                <tr class="border-b hover:bg-gray-50" data-name="{{ p.nombre }} {{ p.referencia }}">
+                  <td class="px-6 py-4"><img src="{{ p.foto_url }}" alt="{{ p.referencia }}" class="h-8 w-8 object-cover"></td>
+                  <td class="px-6 py-4 font-semibold">{{ p.referencia }}</td>
+                  <td class="px-6 py-4"><a href="?section=variacion&var_prod={{ p.id }}" class="text-blue-600 text-sm">Ver</a></td>
+                </tr>
+                {% empty %}
+                <tr><td colspan="3" class="px-6 py-4 text-center text-gray-500">No hay productos.</td></tr>
+                {% endfor %}
+              </tbody>
+            </table>
           </div>
-          {% empty %}
-          <p class="text-gray-500">No hay variaciones registradas.</p>
-          {% endfor %}
+
+          <div class="overflow-x-auto">
+            <h3 class="font-semibold mb-2">Productos sin Variaciones</h3>
+            <table id="sin-var" class="min-w-full text-sm text-left text-gray-700">
+              <thead class="bg-gray-100 text-xs uppercase">
+                <tr><th class="px-6 py-3">Foto</th><th class="px-6 py-3">Referencia</th><th class="px-6 py-3">Acciones</th></tr>
+              </thead>
+              <tbody>
+                {% for p in productos_sin_vars %}
+                <tr class="border-b hover:bg-gray-50" data-name="{{ p.nombre }} {{ p.referencia }}">
+                  <td class="px-6 py-4"><img src="{{ p.foto_url }}" alt="{{ p.referencia }}" class="h-8 w-8 object-cover"></td>
+                  <td class="px-6 py-4 font-semibold">{{ p.referencia }}</td>
+                  <td class="px-6 py-4"><a href="?section=variacion&var_prod={{ p.id }}" class="text-blue-600 text-sm">Agregar</a></td>
+                </tr>
+                {% empty %}
+                <tr><td colspan="3" class="px-6 py-4 text-center text-gray-500">No hay productos.</td></tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+
+          {% if var_prod and producto_sel %}
+          <div class="overflow-x-auto">
+            <h3 class="font-semibold mb-2">Variaciones de {{ producto_sel.referencia }}</h3>
+            <table class="min-w-full text-sm text-left text-gray-700">
+              <thead class="bg-gray-100 text-xs uppercase">
+                <tr><th class="px-6 py-3">Precio</th><th class="px-6 py-3">Valores</th><th class="px-6 py-3">Acciones</th></tr>
+              </thead>
+              <tbody>
+                {% for v in variaciones %}
+                <tr class="border-b hover:bg-gray-50">
+                  <td class="px-6 py-4">${{ v.precio_base|floatformat:0 }}</td>
+                  <td class="px-6 py-4">{% for val in v.valores.all %}{{ val }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
+                  <td class="px-6 py-4">
+                    <a href="?section=variacion&edit_var={{ v.id }}&var_prod={{ producto_sel.id }}" onclick="return confirm('Editar esta variación puede afectar pedidos existentes. ¿Continuar?');" class="text-blue-600 text-sm">Editar</a>
+                    <form method="post" class="inline" onsubmit="return confirm('Eliminar esta variación podría afectar pedidos. ¿Continuar?');">
+                      {% csrf_token %}
+                      <input type="hidden" name="delete_var" value="{{ v.id }}">
+                      <button class="text-red-600 text-sm">Eliminar</button>
+                    </form>
+                  </td>
+                </tr>
+                {% empty %}
+                <tr><td colspan="3" class="px-6 py-4 text-center text-gray-500">No hay variaciones registradas.</td></tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% endif %}
 
         </div>
 
@@ -322,7 +356,7 @@
               {% csrf_token %}
               {{ variacion_form.as_p }}
               <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded-md font-bold hover:bg-green-600 transition-colors">Guardar</button>
-              {% if edit_var %}<a href="?section=variacion" class="ml-2 text-sm">Cancelar</a>{% endif %}
+              {% if edit_var %}<a href="?section=variacion&var_prod={{ var_prod }}" class="ml-2 text-sm">Cancelar</a>{% endif %}
             </form>
           </div>
         </div>
@@ -385,55 +419,47 @@
       <h2 class="text-2xl font-bold text-gray-800">Valores de Atributo</h2>
       <div class="md:flex gap-4">
 
-
-        <div class="md:w-3/4 space-y-4">
-          {% regroup valores by atributo_def.tipo_producto as valores_por_tipo %}
-          {% for tipo in valores_por_tipo %}
-          <div class="border rounded">
-            <div class="bg-gray-50 flex justify-between items-center px-4 py-2">
-              <h3 class="font-semibold">{{ tipo.grouper.nombre }}</h3>
-              <button class="accordion-toggle text-sm text-blue-600" data-target="val-tipo-{{ forloop.counter }}">Ver</button>
-            </div>
-            <div id="val-tipo-{{ forloop.counter }}" class="hidden space-y-2">
-              {% regroup tipo.list by atributo_def as valores_por_atr %}
-              {% for grupo in valores_por_atr %}
-              <div class="border-t">
-                <div class="bg-gray-100 flex justify-between items-center px-4 py-2">
-                  <h4 class="font-semibold">{{ grupo.grouper.nombre }}</h4>
-                  <button class="accordion-toggle text-xs text-blue-600" data-target="val-{{ forloop.parentloop.counter }}-{{ forloop.counter }}">Ver</button>
-                </div>
-                <div id="val-{{ forloop.parentloop.counter }}-{{ forloop.counter }}" class="hidden overflow-x-auto">
-                  <table class="min-w-full text-sm text-left text-gray-700">
-                    <thead class="bg-gray-50 text-xs uppercase">
-                      <tr><th class="px-6 py-3">Valor</th><th class="px-6 py-3">Acciones</th></tr>
-                    </thead>
-                    <tbody>
-                      {% for v in grupo.list %}
-                      <tr class="border-b hover:bg-gray-50 text-sm">
-                        <td class="px-6 py-4">{{ v.valor }}</td>
-                        <td class="px-6 py-4">
-                          <a href="?section=valor&edit_val={{ v.id }}" onclick="return confirm('Editar este valor afectará variaciones que lo usan. ¿Continuar?');" class="bg-blue-500 text-white px-2 py-1 rounded">Editar</a>
-                          <form method="post" class="inline" onsubmit="return confirm('Eliminar este valor podría afectar variaciones. ¿Continuar?');">
-                            {% csrf_token %}
-                            <input type="hidden" name="delete_val" value="{{ v.id }}">
-                            <button class="bg-red-500 text-white px-2 py-1 rounded">Eliminar</button>
-                          </form>
-                        </td>
-                      </tr>
-                      {% endfor %}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
+        <div class="md:w-3/4 overflow-x-auto">
+          <table class="min-w-full text-sm text-left text-gray-700">
+            <thead class="bg-gray-100 text-xs uppercase">
+              <tr>
+                <th class="px-6 py-3">Tipo de Producto</th>
+                <th class="px-6 py-3">Atributo</th>
+                <th class="px-6 py-3">Valores</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% regroup atributos by tipo_producto as atr_por_tipo %}
+              {% for grupo in atr_por_tipo %}
+                {% for atr in grupo.list %}
+                <tr class="border-b hover:bg-gray-50">
+                  {% if forloop.first %}
+                  <td class="px-6 py-4 font-semibold" rowspan="{{ grupo.list|length }}">{{ grupo.grouper.nombre }}</td>
+                  {% endif %}
+                  <td class="px-6 py-4">{{ atr.nombre }}</td>
+                  <td class="px-6 py-4 space-y-1">
+                    {% for v in atr.valores.all %}
+                      <div class="flex items-center gap-2">
+                        <span>{{ v.valor }}</span>
+                        <a href="?section=valor&edit_val={{ v.id }}" class="text-blue-600 text-xs" onclick="return confirm('Editar este valor afectará variaciones que lo usan. ¿Continuar?');">Editar</a>
+                        <form method="post" class="inline" onsubmit="return confirm('Eliminar este valor podría afectar variaciones. ¿Continuar?');">
+                          {% csrf_token %}
+                          <input type="hidden" name="delete_val" value="{{ v.id }}">
+                          <button class="text-red-600 text-xs">Eliminar</button>
+                        </form>
+                      </div>
+                    {% empty %}-{% endfor %}
+                  </td>
+                </tr>
+                {% endfor %}
+              {% empty %}
+                <tr><td colspan="3" class="px-6 py-4 text-center text-gray-500">No hay valores registrados.</td></tr>
               {% endfor %}
-            </div>
-          </div>
-          {% endfor %}
-
+            </tbody>
+          </table>
         </div>
 
         <div class="md:w-1/4 mt-4 md:mt-0">
-
           <div class="bg-white p-6 rounded-lg shadow">
             <h2 class="text-xl font-bold text-gray-800">{% if edit_val %}Editar Valor{% else %}Nuevo Valor{% endif %}</h2>
             <form method="post" class="space-y-4 mt-4">
@@ -444,7 +470,6 @@
             </form>
           </div>
         </div>
-
 
       </div>
     {% elif section == 'cliente' %}
@@ -491,6 +516,16 @@
             if (productoSel.value) {
                 cargarValores(productoSel.value);
             }
+        }
+        const searchInput = document.querySelector('#buscar-producto');
+        if (searchInput) {
+            searchInput.addEventListener('input', () => {
+                const term = searchInput.value.toLowerCase();
+                document.querySelectorAll('#con-var tbody tr, #sin-var tbody tr').forEach(row => {
+                    const name = row.dataset.name.toLowerCase();
+                    row.classList.toggle('hidden', !name.includes(term));
+                });
+            });
         }
         document.querySelectorAll('.toggle-items').forEach(btn => {
             btn.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- filter attribute values in `VariacionProductoForm` when initial product is provided
- allow choosing a product to see only its variations in the admin dashboard
- list products with/without variations in separate tables
- add search box to filter the product tables

## Testing
- `NO_INTERFAZ=1 python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6871cd89b908832ca09a96340b2f2136