### PR TITLE
Fix copy base link and currency display

### DIFF
--- a/catalogo/static/catalogo/script.js
+++ b/catalogo/static/catalogo/script.js
@@ -92,7 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 .filter(val => val.atributoDefId === defId);
             let optionsHTML = valoresDisponibles.map(val => {
                 if (atributoDef.nombre.toLowerCase() === 'color') {
-                     return `<div class="color-swatch" data-atributo-def-id="${defId}" data-valor-id="${val.id}" style="background: ${val.display || '#ccc'};" title="${val.valor}"></div>`;
+                    return `<div class="color-option flex flex-col items-center" data-atributo-def-id="${defId}" data-valor-id="${val.id}"><div class="color-swatch" style="background: ${val.display || '#ccc'};"></div><span class="text-xs mt-1">${val.valor}</span></div>`;
                 }
                 return `<div class="variation-option" data-atributo-def-id="${defId}" data-valor-id="${val.id}">${val.valor}</div>`;
             }).join('');
@@ -537,7 +537,7 @@ document.addEventListener('DOMContentLoaded', () => {
     modalQuantityPlus.addEventListener('click', () => { state.modalSelection.quantity++; updateModalUI(); });
     modalQuantityMinus.addEventListener('click', () => { if (state.modalSelection.quantity > 1) { state.modalSelection.quantity--; updateModalUI(); } });
     modalProductAttributesContainer.addEventListener('click', (e) => {
-        const option = e.target.closest('.variation-option, .color-swatch');
+        const option = e.target.closest('.variation-option, .color-option, .color-swatch');
         if (option) {
             const defId = option.dataset.atributoDefId;
             const valId = Number(option.dataset.valorId);

--- a/catalogo/templates/catalogo/admin_dashboard.html
+++ b/catalogo/templates/catalogo/admin_dashboard.html
@@ -50,7 +50,7 @@
             <div class="text-gray-500">{{ p.cliente.telefono }}</div>
           </td>
           <td class="px-6 py-4 font-bold text-gray-800">
-            ${{ p.total|floatformat:0 }}
+            {{ p.total|moneda }}
           </td>
           <td class="px-6 py-4">
             <!-- PASO 2: Aplicar el filtro de color -->
@@ -104,8 +104,8 @@
                           </div>
                       </td>
                       <td class="py-3 px-2 text-center">{{ item.cantidad }}</td>
-                      <td class="py-3 px-2 text-right">${{ item.precio_unitario|floatformat:0 }}</td>
-                      <td class="py-3 px-2 text-right font-bold text-gray-900">${{ item.subtotal|floatformat:0 }}</td>
+                      <td class="py-3 px-2 text-right">{{ item.precio_unitario|moneda }}</td>
+                      <td class="py-3 px-2 text-right font-bold text-gray-900">{{ item.subtotal|moneda }}</td>
                   </tr>
                   {% endfor %}
                   </tbody>
@@ -314,7 +314,7 @@
                       <tbody>
                         {% for v in p.variaciones.all %}
                         <tr class="border-b">
-                          <td class="px-4 py-2">${{ v.precio_base|floatformat:0 }}</td>
+                            <td class="px-4 py-2">{{ v.precio_base|moneda }}</td>
                           <td class="px-4 py-2">{% for val in v.valores.all %}{{ val }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
                           <td class="px-4 py-2 space-x-2">
                             <a href="?section=variacion&edit_var={{ v.id }}&var_prod={{ p.id }}" class="text-blue-600 text-xs">Editar</a>
@@ -418,7 +418,7 @@
                 <tbody>
                   {% for b in g.list %}
                   <tr class="border-b">
-                    <td class="px-6 py-4">${{ b.precio_base|floatformat:0 }}</td>
+                      <td class="px-6 py-4">{{ b.precio_base|moneda }}</td>
                     <td class="px-6 py-4">{% for v in b.valores.all %}{{ v }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
                     <td class="px-6 py-4 space-x-2">
                       <a href="?section=base&edit_base={{ b.id }}" class="text-blue-600 text-xs">Editar</a>

--- a/catalogo/templates/catalogo/pedido_pdf.html
+++ b/catalogo/templates/catalogo/pedido_pdf.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Pedido #{{ pedido.id }}</title>
+    {% load catalogo_tags %}
     <style>
         @page {
             size: a4 portrait;
@@ -106,9 +107,9 @@
                     </div>
                 </td>
                 <td class="text-right">{{ item.cantidad }}</td>
-                <td class="text-right">${{ item.precio_unitario|floatformat:0 }}</td>
+                <td class="text-right">{{ item.precio_unitario|moneda }}</td>
                 <!-- LÍNEA CORREGIDA -->
-                <td class="text-right font-bold">${{ item.subtotal|floatformat:0 }}</td>
+                <td class="text-right font-bold">{{ item.subtotal|moneda }}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -118,7 +119,7 @@
         <table>
             <tr>
                 <td><strong>TOTAL A PAGAR:</strong></td>
-                <td class="text-right font-bold" style="font-size: 14pt;">${{ pedido.total|floatformat:0 }}</td>
+                  <td class="text-right font-bold" style="font-size: 14pt;">{{ pedido.total|moneda }}</td>
             </tr>
         </table>
     </div>

--- a/catalogo/templatetags/catalogo_tags.py
+++ b/catalogo/templatetags/catalogo_tags.py
@@ -16,4 +16,16 @@ def estado_pedido_color(estado_str):
         'CANCELADO': 'bg-red-100 text-red-800',
     }
     # Devuelve la clase correspondiente o una por defecto si el estado no se encuentra.
+
     return colores.get(estado_str, 'bg-gray-100 text-gray-800')
+
+
+@register.filter(name='moneda')
+def moneda(value):
+    """Formatea valores numéricos como moneda colombiana."""
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return value
+    return "$%s" % ("{:,.0f}".format(value).replace(",", "."))
+

--- a/catalogo/views.py
+++ b/catalogo/views.py
@@ -535,7 +535,12 @@ def valores_por_tipo(request):
 
 @require_http_methods(["POST"])
 def aplicar_variaciones_base(request, producto_id):
-    next_url = request.POST.get('next', reverse('catalogo:admin_dashboard'))
+    next_param = request.POST.get('next')
+    if next_param:
+        base_url = reverse('catalogo:admin_dashboard')
+        next_url = base_url + next_param if next_param.startswith('?') else next_param
+    else:
+        next_url = reverse('catalogo:admin_dashboard')
     try:
         producto = Producto.objects.select_related('categoria__tipo_producto').get(id=producto_id)
     except Producto.DoesNotExist:

--- a/interfaz/templates/interfaz/dashboard.html
+++ b/interfaz/templates/interfaz/dashboard.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load catalogo_tags %}
 
 {% block title %}Dashboard Contable{% endblock %}
 
@@ -11,21 +12,21 @@
   <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
     <div class="bg-slate-800 rounded-lg p-4">
       <h2 class="text-center font-semibold text-slate-400 mb-2">Semana</h2>
-      <p>Ingresos: ${{ totales_semana.ingresos }}</p>
-      <p>Egresos: ${{ totales_semana.egresos }}</p>
-      <p class="font-bold">Saldo: ${{ totales_semana.saldo }}</p>
+        <p>Ingresos: {{ totales_semana.ingresos|moneda }}</p>
+        <p>Egresos: {{ totales_semana.egresos|moneda }}</p>
+        <p class="font-bold">Saldo: {{ totales_semana.saldo|moneda }}</p>
     </div>
     <div class="bg-slate-800 rounded-lg p-4">
       <h2 class="text-center font-semibold text-slate-400 mb-2">Mes</h2>
-      <p>Ingresos: ${{ totales_mes.ingresos }}</p>
-      <p>Egresos: ${{ totales_mes.egresos }}</p>
-      <p class="font-bold">Saldo: ${{ totales_mes.saldo }}</p>
+        <p>Ingresos: {{ totales_mes.ingresos|moneda }}</p>
+        <p>Egresos: {{ totales_mes.egresos|moneda }}</p>
+        <p class="font-bold">Saldo: {{ totales_mes.saldo|moneda }}</p>
     </div>
     <div class="bg-slate-800 rounded-lg p-4">
       <h2 class="text-center font-semibold text-slate-400 mb-2">Año</h2>
-      <p>Ingresos: ${{ totales_anio.ingresos }}</p>
-      <p>Egresos: ${{ totales_anio.egresos }}</p>
-      <p class="font-bold">Saldo: ${{ totales_anio.saldo }}</p>
+        <p>Ingresos: {{ totales_anio.ingresos|moneda }}</p>
+        <p>Egresos: {{ totales_anio.egresos|moneda }}</p>
+        <p class="font-bold">Saldo: {{ totales_anio.saldo|moneda }}</p>
     </div>
   </div>
 
@@ -34,22 +35,22 @@
     {% for c in cuentas_data %}
     <div class="bg-slate-800 rounded-lg p-4 space-y-2">
       <h3 class="text-center font-bold text-cyan-400">{{ c.cuenta.nombre }}</h3>
-      <p class="text-center font-semibold">Saldo actual: ${{ c.saldo_actual }}</p>
+        <p class="text-center font-semibold">Saldo actual: {{ c.saldo_actual|moneda }}</p>
       <div class="grid grid-cols-3 gap-2 text-sm">
         <div>
           <h4 class="text-center text-slate-400 font-semibold mb-1">Semana</h4>
-          <p>Ing: ${{ c.totales_semana.ingresos }}</p>
-          <p>Egr: ${{ c.totales_semana.egresos }}</p>
+            <p>Ing: {{ c.totales_semana.ingresos|moneda }}</p>
+            <p>Egr: {{ c.totales_semana.egresos|moneda }}</p>
         </div>
         <div>
           <h4 class="text-center text-slate-400 font-semibold mb-1">Mes</h4>
-          <p>Ing: ${{ c.totales_mes.ingresos }}</p>
-          <p>Egr: ${{ c.totales_mes.egresos }}</p>
+            <p>Ing: {{ c.totales_mes.ingresos|moneda }}</p>
+            <p>Egr: {{ c.totales_mes.egresos|moneda }}</p>
         </div>
         <div>
           <h4 class="text-center text-slate-400 font-semibold mb-1">Año</h4>
-          <p>Ing: ${{ c.totales_anio.ingresos }}</p>
-          <p>Egr: ${{ c.totales_anio.egresos }}</p>
+            <p>Ing: {{ c.totales_anio.ingresos|moneda }}</p>
+            <p>Egr: {{ c.totales_anio.egresos|moneda }}</p>
         </div>
       </div>
     </div>
@@ -75,8 +76,8 @@
         <tr>
           <td class="px-4 py-2">{{ r.fecha|date:'Y-m-d' }}</td>
           <td class="px-4 py-2">{{ r.descripcion }}</td>
-          <td class="px-4 py-2">{{ r.ingresos }}</td>
-          <td class="px-4 py-2">{{ r.egresos }}</td>
+            <td class="px-4 py-2">{{ r.ingresos|moneda }}</td>
+            <td class="px-4 py-2">{{ r.egresos|moneda }}</td>
           <td class="px-4 py-2">{{ r.cliente.nombre|default:'--' }}</td>
           <td class="px-4 py-2 whitespace-nowrap">
             <a href="{% url 'interfaz:editar_registro' r.id %}" class="text-yellow-400 mr-2">Editar</a>


### PR DESCRIPTION
## Summary
- add `moneda` template filter
- display currency with new filter in admin and dashboard
- show color name below swatch
- update listener for new color markup
- fix redirect in `aplicar_variaciones_base`

## Testing
- `python manage.py check` *(fails: Django missing)*

------
https://chatgpt.com/codex/tasks/task_e_6872bf12f520832cbb572d00488f9adc