### PR TITLE
Disable discount code and rename brand

### DIFF
--- a/catalogo/templates/catalogo/catalogo.html
+++ b/catalogo/templates/catalogo/catalogo.html
@@ -21,7 +21,7 @@
 <body class="bg-gray-50 text-gray-800 font-['Manrope']">
 <div id="app" class="container mx-auto p-4 max-w-4xl">
 <header class="flex justify-between items-center mb-8 pb-4 border-b">
-    <h1 class="text-3xl sm:text-4xl font-extrabold text-gray-900">StickerShop</h1>
+    <h1 class="text-3xl sm:text-4xl font-extrabold text-gray-900">Jema</h1>
     <button id="cart-toggle-btn" class="relative">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"/></svg>
         <span id="cart-count" class="absolute -top-2 -right-2 bg-blue-600 text-white text-xs font-bold rounded-full h-5 w-5 flex items-center justify-center transition-transform duration-300">0</span>

--- a/catalogo/templates/catalogo/pedido_pdf.html
+++ b/catalogo/templates/catalogo/pedido_pdf.html
@@ -72,7 +72,7 @@
 </head>
 <body>
     <div class="company-details">
-        <strong>StickerShop</strong><br>
+        <strong>Jema</strong><br>
         Fecha de Emisión: {% now "d/m/Y" %}
     </div>
 

--- a/catalogo/views.py
+++ b/catalogo/views.py
@@ -263,7 +263,7 @@ def cart_view(request):
                 items.append({
                     'variationId': item.variacion.id,
                     'productoId': item.variacion.producto.id,
-                    'name': item.variacion.producto.nombre,
+                    'name': item.variacion.producto.referencia,
                     'image': item.variacion.producto.foto_url,
                     'priceBase': float(item.variacion.precio_base),
                     'quantity': item.cantidad,


### PR DESCRIPTION
## Summary
- remove promo code UI and logic from shopping cart
- switch WhatsApp checkout message to omit promo code
- send product reference instead of name when restoring carts
- rename brand from StickerShop to Jema in templates

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6878637c9764832cb7c2727042983f09