### PR TITLE
Add per-account movement listing

### DIFF
--- a/interfaz/templates/interfaz/dashboard.html
+++ b/interfaz/templates/interfaz/dashboard.html
@@ -34,8 +34,11 @@
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
     {% for c in cuentas_data %}
     <div class="bg-slate-800 rounded-lg p-4 space-y-2">
-      <h3 class="text-center font-bold text-cyan-400">{{ c.cuenta.nombre }}</h3>
-        <p class="text-center font-semibold">Saldo actual: {{ c.saldo_actual|moneda }}</p>
+      <h3 class="text-center font-bold">
+        <a href="{% url 'interfaz:movimientos_cuenta' c.cuenta.id %}"
+           class="text-cyan-400 hover:underline">{{ c.cuenta.nombre }}</a>
+      </h3>
+      <p class="text-center font-semibold">Saldo actual: {{ c.saldo_actual|moneda }}</p>
       <div class="grid grid-cols-3 gap-2 text-sm">
         <div>
           <h4 class="text-center text-slate-400 font-semibold mb-1">Semana</h4>

--- a/interfaz/templates/interfaz/editar_registro.html
+++ b/interfaz/templates/interfaz/editar_registro.html
@@ -6,10 +6,11 @@
 <div class="max-w-md mx-auto px-4">
   <header class="text-center mb-6">
     <h1 class="text-2xl font-bold text-white">Editar Registro</h1>
-    <a href="{% url 'interfaz:dashboard' %}" class="text-cyan-400 hover:text-cyan-300">← Volver al dashboard</a>
+    <a href="{{ return_url }}" class="text-cyan-400 hover:text-cyan-300">← Volver</a>
   </header>
   <form method="post" class="bg-slate-800 rounded-lg p-6 space-y-4">
     {% csrf_token %}
+    <input type="hidden" name="next" value="{{ return_url }}">
     <div>
       <label for="fecha" class="block mb-1 text-slate-400 font-medium">Fecha</label>
       <input type="date" id="fecha" name="fecha" value="{{ registro.fecha|date:'Y-m-d' }}" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-cyan-500" required>

--- a/interfaz/templates/interfaz/movimientos_cuenta.html
+++ b/interfaz/templates/interfaz/movimientos_cuenta.html
@@ -1,0 +1,60 @@
+{% extends 'base.html' %}
+
+{% block title %}Movimientos de {{ cuenta.nombre }}{% endblock %}
+
+{% block content %}
+<div class="max-w-5xl mx-auto px-4">
+  <header class="text-center mb-6">
+    <h1 class="text-2xl font-bold text-white">Movimientos de {{ cuenta.nombre }}</h1>
+    <a href="{% url 'interfaz:dashboard' %}" class="text-cyan-400 hover:text-cyan-300">← Volver al dashboard</a>
+  </header>
+  <div class="bg-slate-800 rounded-lg overflow-hidden shadow-xl">
+    <table class="w-full text-sm">
+      <thead class="text-slate-400">
+        <tr>
+          <th class="px-4 py-2">Fecha</th>
+          <th class="px-4 py-2">Descripción</th>
+          <th class="px-4 py-2">Categoría</th>
+          <th class="px-4 py-2">Ingresos</th>
+          <th class="px-4 py-2">Egresos</th>
+          <th class="px-4 py-2">Cliente</th>
+          <th class="px-4 py-2">Acciones</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-700">
+        {% for r in registros %}
+        <tr>
+          <td class="px-4 py-2">{{ r.fecha|date:'Y-m-d' }}</td>
+          <td class="px-4 py-2">{{ r.descripcion }}</td>
+          <td class="px-4 py-2">{{ r.categoria.nombre|default:'--' }}</td>
+          <td class="px-4 py-2">{{ r.ingresos|moneda }}</td>
+          <td class="px-4 py-2">{{ r.egresos|moneda }}</td>
+          <td class="px-4 py-2">{{ r.cliente.nombre|default:'--' }}</td>
+          <td class="px-4 py-2 whitespace-nowrap">
+            <a href="{% url 'interfaz:editar_registro' r.id %}?next={% url 'interfaz:movimientos_cuenta' cuenta.id %}" class="text-yellow-400 mr-2">Editar</a>
+            <button onclick="eliminarRegistro({{ r.id }})" class="text-red-500">Eliminar</button>
+          </td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="7" class="text-center py-4 text-slate-500">Sin registros</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <form id="delete-form" method="post" class="hidden">{% csrf_token %}</form>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+async function eliminarRegistro(id){
+  if(!confirm('¿Eliminar el registro?')) return;
+  const form = document.getElementById('delete-form');
+  await fetch(`{% url 'interfaz:eliminar_registro' 0 %}`.replace('0', id), {
+    method: 'POST',
+    headers: {'X-CSRFToken': form.querySelector('input[name="csrfmiddlewaretoken"]').value}
+  });
+  window.location.reload();
+}
+</script>
+{% endblock %}

--- a/interfaz/urls.py
+++ b/interfaz/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('registrar/', views.registrar_datos, name='registrar'),
     path('crear/categoria/', views.crear_categoria, name='crear_categoria'),
     path('crear/cuenta/', views.crear_cuenta, name='crear_cuenta'),
+    path('cuenta/<int:cuenta_id>/', views.movimientos_cuenta, name='movimientos_cuenta'),
     path('editar/<int:registro_id>/', views.editar_registro, name='editar_registro'),
     path('eliminar/<int:registro_id>/', views.eliminar_registro, name='eliminar_registro'),
 ]


### PR DESCRIPTION
## Summary
- add link on dashboard account cards to view account movements
- implement movements_cuenta view and URL with edit/delete controls
- allow editing view to redirect back to originating page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688ea84266fc832ca8a0a0a3092c7515