### PR TITLE
Simplify totals calculation with single aggregation

### DIFF
--- a/interfaz/views.py
+++ b/interfaz/views.py
@@ -151,8 +151,10 @@ def registrar_datos(request):
 
 
 def _totales_desde(qs):
-    ingresos = qs.aggregate(total=Sum('ingresos'))['total'] or 0
-    egresos = qs.aggregate(total=Sum('egresos'))['total'] or 0
+    """Return total incomes, expenses and balance for a queryset."""
+    totales = qs.aggregate(ing=Sum('ingresos'), egr=Sum('egresos'))
+    ingresos = totales['ing'] or 0
+    egresos = totales['egr'] or 0
     return {
         'ingresos': ingresos,
         'egresos': egresos,


### PR DESCRIPTION
## Summary
- Simplify `_totales_desde` by using a single aggregate query for incomes and expenses
- Compute totals from aggregation result and return consolidated dictionary

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688eb7a2e208832ca6f80c90bcdd944b