### PR TITLE
Add manual input fallbacks and task board enhancements

### DIFF
--- a/gestor_tareas/templates/gestor_tareas/agregar_tarea.html
+++ b/gestor_tareas/templates/gestor_tareas/agregar_tarea.html
@@ -19,6 +19,7 @@
             <button id="talkButton" class="mx-auto flex items-center justify-center w-20 h-20 sm:w-24 sm:h-24 rounded-full bg-cyan-600 hover:bg-cyan-700 transition-all focus:outline-none focus:ring-4 focus:ring-cyan-500">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-10 h-10"><path d="M7 4a3 3 0 016 0v6a3 3 0 11-6 0V4z" /><path fill-rule="evenodd" d="M5.5 8.5A.5.5 0 016 9v1a4 4 0 004 4h.01a4 4 0 004-4V9a.5.5 0 011 0v1a5 5 0 01-4.5 4.975V17h1.5a.5.5 0 010 1h-4a.5.5 0 010-1H10v-2.025A5 5 0 015.5 10V9a.5.5 0 01.5-.5z" clip-rule="evenodd" /></svg>
             </button>
+            <button id="manualButton" class="mt-4 w-full bg-slate-700 hover:bg-slate-600 rounded-lg py-2 hidden">Ingresar manualmente</button>
 
             <!-- El formulario se inyectará aquí con JavaScript -->
             <form id="formContainer" class="hidden mt-8 space-y-4 text-sm"></form>
@@ -38,14 +39,20 @@
     const instructionText = document.getElementById('instructionText');
     const statusBox = document.getElementById('statusBox');
     const transcriptionBox = document.getElementById('transcriptionBox');
+    const manualButton = document.getElementById('manualButton');
     let isRecording = false;
     let tomSelectTipo;
+
+    const TIPOS_INICIALES = {{ tipos|safe }};
+    const PRIORIDADES_INICIALES = {{ prioridades|safe }};
+    const ESTADOS_INICIALES = {{ estados|safe }};
 
     // --- Lógica de la API de Voz (a prueba de fallos) ---
     const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
     if (!SpeechRecognition) {
       statusBox.textContent = 'Tu navegador no soporta la API de voz.';
       talkButton.disabled = true;
+      manualButton.classList.remove('hidden');
     } else {
       const recognition = new SpeechRecognition();
       recognition.lang = 'es-ES';
@@ -89,8 +96,8 @@
         transcriptionBox.innerHTML = `<i>${finalTranscript}</i><i class="text-slate-500">${interimTranscript}</i>`;
       };
       
-      recognition.onerror = (event) => { statusBox.textContent = `Error: ${event.error}`; };
-      
+      recognition.onerror = (event) => { statusBox.textContent = `Error: ${event.error}`; manualButton.classList.remove('hidden'); };
+
       talkButton.addEventListener('click', () => {
         if (isRecording) {
           recognition.stop();
@@ -100,8 +107,22 @@
             recognition.start();
           } catch(e) {
             statusBox.textContent = 'Error al iniciar micrófono. Intenta de nuevo.';
+            manualButton.classList.remove('hidden');
           }
         }
+      });
+    }
+
+    manualButton.addEventListener('click', () => {
+      mostrarFormularioManual();
+    });
+
+    function mostrarFormularioManual(){
+      populateAndShowForm({
+        datos_extraidos: {},
+        todos_los_tipos: TIPOS_INICIALES,
+        todas_las_prioridades: PRIORIDADES_INICIALES,
+        todos_los_estados: ESTADOS_INICIALES,
       });
     }
 

--- a/gestor_tareas/templates/gestor_tareas/lista_tareas.html
+++ b/gestor_tareas/templates/gestor_tareas/lista_tareas.html
@@ -3,7 +3,8 @@
 {% block title %}Lista de Tareas{% endblock %}
 
 {% block content %}
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex gap-4">
+    <div class="flex-1">
     <header class="flex flex-col sm:flex-row justify-between items-center mb-6 gap-4">
         <h1 class="text-3xl font-bold text-white text-center sm:text-left">
             Gestor de <span class="text-cyan-400">Tareas</span>
@@ -16,12 +17,12 @@
         </a>
     </header>
 
-    <div id="status-message" class="mb-4 text-center font-medium h-6 transition-opacity duration-300"></div>
+        <div id="status-message" class="mb-4 text-center font-medium h-6 transition-opacity duration-300"></div>
 
-    <div class="bg-slate-800 rounded-lg shadow-xl overflow-hidden">
-        <div class="overflow-x-auto">
-            <table class="w-full text-sm text-left table-auto">
-                <thead class="text-xs text-slate-400 uppercase">
+        <div class="bg-slate-800 rounded-lg shadow-xl overflow-hidden">
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm text-left table-auto">
+                    <thead class="text-xs text-slate-400 uppercase">
                     <tr>
                         <th class="px-4 py-3">Orden</th>
                         <th class="px-4 py-3">Recibido</th>
@@ -33,9 +34,9 @@
                         <th class="px-4 py-3">Acciones</th>
                     </tr>
                 </thead>
-                <tbody class="divide-y divide-slate-700">
-                    {% for tarea in tareas %}
-                    <tr id="tarea-row-{{ tarea.id }}" class="hover:bg-slate-700/50 transition-colors duration-200 {% if tarea.estado == 'Completado' %}completed-row{% endif %}">
+                    <tbody id="tareas-body" class="divide-y divide-slate-700">
+                        {% for tarea in tareas %}
+                        <tr id="tarea-row-{{ tarea.id }}" draggable="true" class="hover:bg-slate-700/50 transition-colors duration-200 {% if tarea.estado == 'Recibido' %}bg-blue-900/20{% elif tarea.estado == 'En Proceso' %}bg-yellow-900/20{% elif tarea.estado == 'Completado' %}bg-green-900/20 completed-row{% endif %}">
 
                         <td class="px-4 py-3 text-xl font-bold text-white">{{ tarea.orden|default:0 }}</td>
 
@@ -84,15 +85,24 @@
                         </td>
 
                     </tr>
-                    {% empty %}
-                    <tr>
-                        <td colspan="8" class="text-center py-10 text-slate-500">No hay tareas visibles. ¡Agrega la primera!</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                        {% empty %}
+                        <tr>
+                            <td colspan="8" class="text-center py-10 text-slate-500">No hay tareas visibles. ¡Agrega la primera!</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
+    <aside class="w-64 bg-slate-800 rounded-lg p-4 text-sm">
+        <h2 class="text-center font-bold mb-2">Notas</h2>
+        <form id="noteForm" class="flex gap-2">
+            <input id="noteInput" type="text" class="flex-grow bg-slate-700 p-1 rounded" placeholder="Nueva nota...">
+            <button type="submit" class="bg-green-600 px-2 rounded">+</button>
+        </form>
+        <ul id="notesList" class="mt-4 space-y-2"></ul>
+    </aside>
 </div>
 {% endblock %}
 
@@ -182,5 +192,88 @@
             fullEl.classList.toggle('hidden');
         }
     }
+
+    // --- Drag and drop para reordenar tareas ---
+    const tbody = document.getElementById('tareas-body');
+    let draggedRow = null;
+    tbody.addEventListener('dragstart', (e) => {
+        draggedRow = e.target.closest('tr');
+        e.dataTransfer.effectAllowed = 'move';
+    });
+    tbody.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        const target = e.target.closest('tr');
+        if (!target || target === draggedRow) return;
+        const rect = target.getBoundingClientRect();
+        const next = (e.clientY - rect.top) / (rect.bottom - rect.top) > 0.5;
+        tbody.insertBefore(draggedRow, next ? target.nextSibling : target);
+    });
+    tbody.addEventListener('drop', (e) => {
+        e.preventDefault();
+        actualizarOrdenesServidor();
+    });
+
+    async function actualizarOrdenesServidor(){
+        const rows = [...tbody.querySelectorAll('tr')];
+        const ordenes = [];
+        rows.forEach((row, idx) => {
+            row.querySelector('td').textContent = idx + 1;
+            const id = row.id.split('-')[2];
+            ordenes.push({id: id, orden: idx + 1});
+        });
+        await fetch("{% url 'gestor_tareas:reordenar_tareas' %}", {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': '{{ csrf_token }}' },
+            body: JSON.stringify({ ordenes })
+        });
+    }
+
+    // --- Sidebar de notas ---
+    const notesList = document.getElementById('notesList');
+    const noteForm = document.getElementById('noteForm');
+    const noteInput = document.getElementById('noteInput');
+
+    function loadNotes(){
+        const notes = JSON.parse(localStorage.getItem('tareasNotas') || '[]');
+        notesList.innerHTML = '';
+        notes.forEach((note, idx) => {
+            const li = document.createElement('li');
+            li.className = 'relative bg-slate-700 p-2 rounded';
+            const span = document.createElement('span');
+            span.textContent = note;
+            span.addEventListener('dblclick', () => {
+                const nuevo = prompt('Editar nota', note);
+                if(nuevo !== null){
+                    notes[idx] = nuevo;
+                    localStorage.setItem('tareasNotas', JSON.stringify(notes));
+                    loadNotes();
+                }
+            });
+            const btn = document.createElement('button');
+            btn.textContent = 'x';
+            btn.className = 'absolute top-1 right-1 text-red-400';
+            btn.addEventListener('click', () => {
+                notes.splice(idx,1);
+                localStorage.setItem('tareasNotas', JSON.stringify(notes));
+                loadNotes();
+            });
+            li.appendChild(span);
+            li.appendChild(btn);
+            notesList.appendChild(li);
+        });
+    }
+
+    noteForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const text = noteInput.value.trim();
+        if(!text) return;
+        const notes = JSON.parse(localStorage.getItem('tareasNotas') || '[]');
+        notes.push(text);
+        localStorage.setItem('tareasNotas', JSON.stringify(notes));
+        noteInput.value = '';
+        loadNotes();
+    });
+
+    loadNotes();
 </script>
 {% endblock %}

--- a/gestor_tareas/urls.py
+++ b/gestor_tareas/urls.py
@@ -11,7 +11,8 @@ urlpatterns = [
     path('registrar/', views.registrar_tarea, name='registrar_tarea'),
     path('crear/tipo/', views.crear_tipo_trabajo, name='crear_tipo'),
     path('actualizar-estado/', views.actualizar_estado_tarea, name='actualizar_estado'),
-    
+    path('reordenar/', views.reordenar_tareas, name='reordenar_tareas'),
+
     # <-- NUEVAS RUTAS -->
     path('editar/<int:tarea_id>/', views.editar_tarea, name='editar_tarea'),
     path('ocultar/<int:tarea_id>/', views.ocultar_tarea, name='ocultar_tarea'),

--- a/interfaz/templates/interfaz/dashboard.html
+++ b/interfaz/templates/interfaz/dashboard.html
@@ -7,25 +7,26 @@
 <div class="max-w-5xl mx-auto px-4">
   <header class="text-center mb-8">
     <h1 class="text-3xl font-bold text-white">Resumen de <span class="text-green-400">Contabilidad</span></h1>
+    <p class="text-2xl mt-2">Saldo total: <span class="text-green-400">{{ saldo_total_general|moneda }}</span></p>
   </header>
 
   <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
     <div class="bg-slate-800 rounded-lg p-4">
       <h2 class="text-center font-semibold text-slate-400 mb-2">Semana</h2>
-        <p>Ingresos: {{ totales_semana.ingresos|moneda }}</p>
-        <p>Egresos: {{ totales_semana.egresos|moneda }}</p>
+        <p class="text-blue-400">Ingresos: {{ totales_semana.ingresos|moneda }}</p>
+        <p class="text-red-400">Egresos: {{ totales_semana.egresos|moneda }}</p>
         <p class="font-bold">Saldo: {{ totales_semana.saldo|moneda }}</p>
     </div>
     <div class="bg-slate-800 rounded-lg p-4">
       <h2 class="text-center font-semibold text-slate-400 mb-2">Mes</h2>
-        <p>Ingresos: {{ totales_mes.ingresos|moneda }}</p>
-        <p>Egresos: {{ totales_mes.egresos|moneda }}</p>
+        <p class="text-blue-400">Ingresos: {{ totales_mes.ingresos|moneda }}</p>
+        <p class="text-red-400">Egresos: {{ totales_mes.egresos|moneda }}</p>
         <p class="font-bold">Saldo: {{ totales_mes.saldo|moneda }}</p>
     </div>
     <div class="bg-slate-800 rounded-lg p-4">
       <h2 class="text-center font-semibold text-slate-400 mb-2">Año</h2>
-        <p>Ingresos: {{ totales_anio.ingresos|moneda }}</p>
-        <p>Egresos: {{ totales_anio.egresos|moneda }}</p>
+        <p class="text-blue-400">Ingresos: {{ totales_anio.ingresos|moneda }}</p>
+        <p class="text-red-400">Egresos: {{ totales_anio.egresos|moneda }}</p>
         <p class="font-bold">Saldo: {{ totales_anio.saldo|moneda }}</p>
     </div>
   </div>
@@ -33,29 +34,13 @@
   <h2 class="text-xl font-semibold mb-4">Resumen por Cuenta</h2>
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
     {% for c in cuentas_data %}
-    <div class="bg-slate-800 rounded-lg p-4 space-y-2">
-      <h3 class="text-center font-bold">
+    <div class="bg-slate-800 rounded-lg p-4 space-y-2 text-center">
+      <h3 class="font-bold">
         <a href="{% url 'interfaz:movimientos_cuenta' c.cuenta.id %}"
            class="text-cyan-400 hover:underline">{{ c.cuenta.nombre }}</a>
       </h3>
-      <p class="text-center font-semibold">Saldo actual: {{ c.saldo_actual|moneda }}</p>
-      <div class="grid grid-cols-3 gap-2 text-sm">
-        <div>
-          <h4 class="text-center text-slate-400 font-semibold mb-1">Semana</h4>
-            <p>Ing: {{ c.totales_semana.ingresos|moneda }}</p>
-            <p>Egr: {{ c.totales_semana.egresos|moneda }}</p>
-        </div>
-        <div>
-          <h4 class="text-center text-slate-400 font-semibold mb-1">Mes</h4>
-            <p>Ing: {{ c.totales_mes.ingresos|moneda }}</p>
-            <p>Egr: {{ c.totales_mes.egresos|moneda }}</p>
-        </div>
-        <div>
-          <h4 class="text-center text-slate-400 font-semibold mb-1">Año</h4>
-            <p>Ing: {{ c.totales_anio.ingresos|moneda }}</p>
-            <p>Egr: {{ c.totales_anio.egresos|moneda }}</p>
-        </div>
-      </div>
+      <p class="text-2xl font-bold text-green-400">{{ c.saldo_actual|moneda }}</p>
+      <p class="text-xl text-blue-400">Ingreso mensual: {{ c.totales_mes.ingresos|moneda }}</p>
     </div>
     {% empty %}
     <p class="text-slate-500">Sin cuentas registradas.</p>
@@ -68,8 +53,8 @@
         <tr>
           <th class="px-4 py-2">Fecha</th>
           <th class="px-4 py-2">Descripción</th>
-          <th class="px-4 py-2">Ingresos</th>
-          <th class="px-4 py-2">Egresos</th>
+          <th class="px-4 py-2 text-blue-400">Ingresos</th>
+          <th class="px-4 py-2 text-red-400">Egresos</th>
           <th class="px-4 py-2">Cliente</th>
           <th class="px-4 py-2">Acciones</th>
         </tr>
@@ -79,8 +64,8 @@
         <tr>
           <td class="px-4 py-2">{{ r.fecha|date:'Y-m-d' }}</td>
           <td class="px-4 py-2">{{ r.descripcion }}</td>
-            <td class="px-4 py-2">{{ r.ingresos|moneda }}</td>
-            <td class="px-4 py-2">{{ r.egresos|moneda }}</td>
+            <td class="px-4 py-2 text-blue-400">{{ r.ingresos|moneda }}</td>
+            <td class="px-4 py-2 text-red-400">{{ r.egresos|moneda }}</td>
           <td class="px-4 py-2">{{ r.cliente.nombre|default:'--' }}</td>
           <td class="px-4 py-2 whitespace-nowrap">
             <a href="{% url 'interfaz:editar_registro' r.id %}" class="text-yellow-400 mr-2">Editar</a>

--- a/interfaz/templates/interfaz/movimientos_cuenta.html
+++ b/interfaz/templates/interfaz/movimientos_cuenta.html
@@ -18,8 +18,8 @@
           <th class="px-4 py-2">Fecha</th>
           <th class="px-4 py-2">Descripción</th>
           <th class="px-4 py-2">Categoría</th>
-          <th class="px-4 py-2">Ingresos</th>
-          <th class="px-4 py-2">Egresos</th>
+          <th class="px-4 py-2 text-blue-400">Ingresos</th>
+          <th class="px-4 py-2 text-red-400">Egresos</th>
           <th class="px-4 py-2">Cliente</th>
           <th class="px-4 py-2">Acciones</th>
         </tr>
@@ -30,8 +30,8 @@
           <td class="px-4 py-2">{{ r.fecha|date:'Y-m-d' }}</td>
           <td class="px-4 py-2">{{ r.descripcion }}</td>
           <td class="px-4 py-2">{{ r.categoria.nombre|default:'--' }}</td>
-          <td class="px-4 py-2">{{ r.ingresos|moneda }}</td>
-          <td class="px-4 py-2">{{ r.egresos|moneda }}</td>
+          <td class="px-4 py-2 text-blue-400">{{ r.ingresos|moneda }}</td>
+          <td class="px-4 py-2 text-red-400">{{ r.egresos|moneda }}</td>
           <td class="px-4 py-2">{{ r.cliente.nombre|default:'--' }}</td>
           <td class="px-4 py-2 whitespace-nowrap">
             <a href="{% url 'interfaz:editar_registro' r.id %}?next={% url 'interfaz:movimientos_cuenta' cuenta.id %}" class="text-yellow-400 mr-2">Editar</a>

--- a/interfaz/templates/interfaz/voz.html
+++ b/interfaz/templates/interfaz/voz.html
@@ -19,6 +19,7 @@
             <button id="talkButton" class="mx-auto flex items-center justify-center w-20 h-20 sm:w-24 sm:h-24 rounded-full bg-green-600 hover:bg-green-700 transition-all focus:outline-none focus:ring-4 focus:ring-green-500">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-10 h-10"><path d="M7 4a3 3 0 016 0v6a3 3 0 11-6 0V4z" /><path fill-rule="evenodd" d="M5.5 8.5A.5.5 0 016 9v1a4 4 0 004 4h.01a4 4 0 004-4V9a.5.5 0 011 0v1a5 5 0 01-4.5 4.975V17h1.5a.5.5 0 010 1h-4a.5.5 0 010-1H10v-2.025A5 5 0 015.5 10V9a.5.5 0 01.5-.5z" clip-rule="evenodd"/></svg>
             </button>
+            <button id="manualButton" class="mt-4 w-full bg-slate-700 hover:bg-slate-600 rounded-lg py-2 hidden">Ingresar manualmente</button>
             <form id="formContainer" class="hidden mt-8 space-y-4 text-sm"></form>
         </section>
         <div id="statusBox" class="min-h-[1.75rem] text-center text-sm font-medium text-slate-400"></div>
@@ -34,13 +35,18 @@ const formContainer = document.getElementById('formContainer');
 const instructionText = document.getElementById('instructionText');
 const statusBox = document.getElementById('statusBox');
 const transcriptionBox = document.getElementById('transcriptionBox');
+const manualButton = document.getElementById('manualButton');
 let isRecording = false;
 let tomSelectCategoria, tomSelectCuenta;
+
+const CATEGORIAS_INICIALES = {{ categorias|safe }};
+const CUENTAS_INICIALES = {{ cuentas|safe }};
 
 const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
 if (!SpeechRecognition) {
   statusBox.textContent = 'Tu navegador no soporta la API de voz.';
   talkButton.disabled = true;
+  manualButton.classList.remove('hidden');
 } else {
   const recognition = new SpeechRecognition();
   recognition.lang = 'es-ES';
@@ -82,15 +88,27 @@ if (!SpeechRecognition) {
     transcriptionBox.innerHTML = `<i>${finalTranscript}</i><i class="text-slate-500">${interimTranscript}</i>`;
   };
 
-  recognition.onerror = (event) => { statusBox.textContent = `Error: ${event.error}`; };
+  recognition.onerror = (event) => { statusBox.textContent = `Error: ${event.error}`; manualButton.classList.remove('hidden'); };
 
   talkButton.addEventListener('click', () => {
     if (isRecording) {
       recognition.stop();
     } else {
       resetState();
-      try { recognition.start(); } catch(e) { statusBox.textContent = 'Error al iniciar micrófono.'; }
+      try { recognition.start(); } catch(e) { statusBox.textContent = 'Error al iniciar micrófono.'; manualButton.classList.remove('hidden'); }
     }
+  });
+}
+
+manualButton.addEventListener('click', () => {
+  mostrarFormularioManual();
+});
+
+function mostrarFormularioManual(){
+  populateAndShowForm({
+    datos_extraidos: {},
+    todas_las_categorias: CATEGORIAS_INICIALES,
+    todas_las_cuentas: CUENTAS_INICIALES,
   });
 }
 

--- a/interfaz/views.py
+++ b/interfaz/views.py
@@ -32,7 +32,14 @@ HEADERS = ["fecha", "categoria", "cuenta", "descripcion", "egresos", "ingresos"]
 
 
 def home(request):
-    return render(request, 'interfaz/voz.html')
+    return render(
+        request,
+        'interfaz/voz.html',
+        {
+            'categorias': list(Categoria.objects.values_list('nombre', flat=True)),
+            'cuentas': list(Cuenta.objects.values_list('nombre', flat=True)),
+        },
+    )
 
 
 @csrf_exempt
@@ -198,14 +205,15 @@ def dashboard(request):
             }
         )
 
+    saldo_total_general = sum(c['saldo_actual'] for c in cuentas_data)
+
     context = {
         'totales_semana': totales_semana,
         'totales_mes': totales_mes,
         'totales_anio': totales_anio,
         'registros_recientes': recientes,
-
         'cuentas_data': cuentas_data,
-
+        'saldo_total_general': saldo_total_general,
     }
     return render(request, 'interfaz/dashboard.html', context)
 


### PR DESCRIPTION
## Summary
- Color ingresos in blue and egresos in red across accounting pages
- Show total balance on dashboard and simplify account cards
- Add manual input fallback and notes sidebar with drag-and-drop ordering for tasks

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c0a97255d0832c8a9bb7e144a6b62f