### PR TITLE
Extend light theme and task list filters

### DIFF
--- a/gestor_tareas/templates/gestor_tareas/agregar_tarea.html
+++ b/gestor_tareas/templates/gestor_tareas/agregar_tarea.html
@@ -5,28 +5,28 @@
 {% block content %}
 <div class="flex flex-col items-center justify-center px-4">
     <header class="w-full max-w-md text-center mb-8">
-        <h1 class="text-3xl sm:text-4xl font-extrabold tracking-tight">
-            Gestor de <span class="text-cyan-400">Tareas</span>
+        <h1 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-[#0F172A]">
+            Gestor de <span class="text-teal-600">Tareas</span>
         </h1>
-        <a href="{% url 'gestor_tareas:lista_tareas' %}" class="text-cyan-400 hover:text-cyan-300 mt-2 inline-block">← Volver a la lista</a>
+        <a href="{% url 'gestor_tareas:lista_tareas' %}" class="text-teal-600 hover:underline mt-2 inline-block">← Volver a la lista</a>
     </header>
 
     <main class="w-full max-w-md space-y-6">
-        <section id="interactionContainer" class="w-full bg-slate-800/60 backdrop-blur rounded-2xl shadow-2xl p-6">
-            <p id="instructionText" class="text-center text-base sm:text-lg text-cyan-400 mb-6">
+        <section id="interactionContainer" class="w-full bg-white rounded-2xl shadow p-6">
+            <p id="instructionText" class="text-center text-base sm:text-lg text-gray-700 mb-6">
                 Presiona para dictar una nueva tarea.
             </p>
-            <button id="talkButton" class="mx-auto flex items-center justify-center w-20 h-20 sm:w-24 sm:h-24 rounded-full bg-cyan-600 hover:bg-cyan-700 transition-all focus:outline-none focus:ring-4 focus:ring-cyan-500">
+            <button id="talkButton" class="mx-auto flex items-center justify-center w-20 h-20 sm:w-24 sm:h-24 rounded-full bg-teal-600 hover:bg-teal-700 transition-all focus:outline-none focus:ring-4 focus:ring-teal-500">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-10 h-10"><path d="M7 4a3 3 0 016 0v6a3 3 0 11-6 0V4z" /><path fill-rule="evenodd" d="M5.5 8.5A.5.5 0 016 9v1a4 4 0 004 4h.01a4 4 0 004-4V9a.5.5 0 011 0v1a5 5 0 01-4.5 4.975V17h1.5a.5.5 0 010 1h-4a.5.5 0 010-1H10v-2.025A5 5 0 015.5 10V9a.5.5 0 01.5-.5z" clip-rule="evenodd" /></svg>
             </button>
-            <button id="manualButton" class="mt-4 w-full bg-slate-700 hover:bg-slate-600 rounded-lg py-2 hidden">Ingresar manualmente</button>
+            <button id="manualButton" class="mt-4 w-full bg-gray-100 hover:bg-gray-200 rounded-lg py-2 hidden">Ingresar manualmente</button>
 
             <!-- El formulario se inyectará aquí con JavaScript -->
             <form id="formContainer" class="hidden mt-8 space-y-4 text-sm"></form>
         </section>
 
-        <div id="statusBox" class="min-h-[1.75rem] text-center text-sm font-medium text-slate-400"></div>
-        <div id="transcriptionBox" class="bg-slate-800/40 rounded-lg p-3 text-xs text-slate-400 italic"></div>
+        <div id="statusBox" class="min-h-[1.75rem] text-center text-sm font-medium text-gray-500"></div>
+        <div id="transcriptionBox" class="bg-white rounded-lg p-3 text-xs text-gray-500 italic shadow"></div>
     </main>
 </div>
 {% endblock %}

--- a/gestor_tareas/templates/gestor_tareas/editar_tarea.html
+++ b/gestor_tareas/templates/gestor_tareas/editar_tarea.html
@@ -1,78 +1,61 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Editar Tarea #{{ tarea.id }}</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
-    <style> body { font-family: 'Inter', sans-serif; } </style>
-</head>
-<body class="bg-gradient-to-b from-slate-900 to-slate-800 text-white min-h-screen flex flex-col items-center justify-center px-4 py-6">
+{% extends 'base.html' %}
 
-    <main class="w-full max-w-lg">
-        <header class="text-center mb-8">
-            <h1 class="text-3xl font-bold text-white">Editar Tarea <span class="text-cyan-400">#{{ tarea.id }}</span></h1>
-            <a href="{% url 'gestor_tareas:lista_tareas' %}" class="text-cyan-400 hover:text-cyan-300 mt-2 inline-block">← Cancelar y volver a la lista</a>
-        </header>
+{% block title %}Editar Tarea #{{ tarea.id }}{% endblock %}
 
-        <form method="POST" action="{% url 'gestor_tareas:editar_tarea' tarea.id %}" class="bg-slate-800/60 backdrop-blur rounded-2xl shadow-2xl p-8 space-y-6">
-            {% csrf_token %}
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-                <!-- Cliente -->
-                <div>
-                    <label for="cliente" class="block mb-1 text-slate-400 font-medium">Cliente</label>
-                    <input type="text" name="cliente" id="cliente" value="{{ tarea.cliente }}" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-cyan-500" required>
-                </div>
-                <!-- Teléfono -->
-                <div>
-                    <label for="telefono" class="block mb-1 text-slate-400 font-medium">Teléfono (Opcional)</label>
-                    <input type="tel" name="telefono" id="telefono" value="{{ tarea.telefono|default_if_none:'' }}" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-cyan-500">
-                </div>
-                <!-- Orden -->
-                <div>
-                    <label for="orden" class="block mb-1 text-slate-400 font-medium">Orden</label>
-                    <input type="number" name="orden" id="orden" value="{{ tarea.orden|default_if_none:'' }}" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-cyan-500">
-                </div>
-                <!-- Tipo de Trabajo -->
-                <div class="sm:col-span-2">
-                    <label for="tipo" class="block mb-1 text-slate-400 font-medium">Tipo de Trabajo</label>
-                    <select name="tipo" id="tipo" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-cyan-500">
-                        <option value="">-- Ninguno --</option>
-                        {% for tipo in todos_los_tipos %}
-                        <option value="{{ tipo.nombre }}" {% if tarea.tipo.id == tipo.id %}selected{% endif %}>{{ tipo.nombre }}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-                <!-- Prioridad -->
-                <div>
-                    <label for="prioridad" class="block mb-1 text-slate-400 font-medium">Prioridad</label>
-                    <select name="prioridad" id="prioridad" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-cyan-500">
-                        {% for value, label in todas_las_prioridades %}
-                        <option value="{{ value }}" {% if tarea.prioridad == value %}selected{% endif %}>{{ label }}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-                <!-- Estado -->
-                <div>
-                    <label for="estado" class="block mb-1 text-slate-400 font-medium">Estado</label>
-                    <select name="estado" id="estado" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-cyan-500">
-                        {% for value, label in todos_los_estados %}
-                        <option value="{{ value }}" {% if tarea.estado == value %}selected{% endif %}>{{ label }}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-                 <!-- Descripción -->
-                 <div class="sm:col-span-2">
-                    <label for="descripcion" class="block mb-1 text-slate-400 font-medium">Descripción</label>
-                    <textarea name="descripcion" id="descripcion" rows="4" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-cyan-500">{{ tarea.descripcion }}</textarea>
-                </div>
-            </div>
-
-            <div class="flex justify-center pt-4">
-                <button type="submit" class="bg-green-600 hover:bg-green-700 py-3 px-8 rounded-lg font-semibold text-base">Guardar Cambios</button>
-            </div>
-        </form>
-    </main>
-</body>
-</html>
+{% block content %}
+<div class="max-w-xl mx-auto px-4">
+  <header class="mb-6">
+    <h1 class="text-2xl font-bold text-[#0F172A]">Editar Tarea <span class="text-teal-600">#{{ tarea.id }}</span></h1>
+    <a href="{% url 'gestor_tareas:lista_tareas' %}" class="text-teal-600 hover:underline">← Cancelar y volver a la lista</a>
+  </header>
+  <form method="POST" action="{% url 'gestor_tareas:editar_tarea' tarea.id %}" class="bg-white rounded-lg shadow p-6 space-y-4">
+    {% csrf_token %}
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div>
+        <label for="cliente" class="block mb-1 text-sm font-medium text-gray-700">Cliente</label>
+        <input type="text" name="cliente" id="cliente" value="{{ tarea.cliente }}" class="w-full border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-teal-500" required>
+      </div>
+      <div>
+        <label for="telefono" class="block mb-1 text-sm font-medium text-gray-700">Teléfono (Opcional)</label>
+        <input type="tel" name="telefono" id="telefono" value="{{ tarea.telefono|default_if_none:'' }}" class="w-full border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-teal-500">
+      </div>
+      <div>
+        <label for="orden" class="block mb-1 text-sm font-medium text-gray-700">Orden</label>
+        <input type="number" name="orden" id="orden" value="{{ tarea.orden|default_if_none:'' }}" class="w-full border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-teal-500">
+      </div>
+      <div class="sm:col-span-2">
+        <label for="tipo" class="block mb-1 text-sm font-medium text-gray-700">Tipo de Trabajo</label>
+        <select name="tipo" id="tipo" class="w-full border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-teal-500">
+          {% for tipo in todos_los_tipos %}
+          <option value="{{ tipo.nombre }}" {% if tarea.tipo and tarea.tipo.id == tipo.id %}selected{% endif %}>{{ tipo.nombre }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label for="prioridad" class="block mb-1 text-sm font-medium text-gray-700">Prioridad</label>
+        <select name="prioridad" id="prioridad" class="w-full border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-teal-500">
+          {% for value,label in todas_las_prioridades %}
+          <option value="{{ value }}" {% if tarea.prioridad == value %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label for="estado" class="block mb-1 text-sm font-medium text-gray-700">Estado</label>
+        <select name="estado" id="estado" class="w-full border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-teal-500">
+          {% for value,label in todos_los_estados %}
+          <option value="{{ value }}" {% if tarea.estado == value %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="sm:col-span-2">
+        <label for="descripcion" class="block mb-1 text-sm font-medium text-gray-700">Descripción</label>
+        <textarea name="descripcion" id="descripcion" rows="4" class="w-full border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-teal-500">{{ tarea.descripcion }}</textarea>
+      </div>
+    </div>
+    <div class="flex justify-end gap-4 pt-4">
+       <button type="submit" class="bg-teal-600 hover:bg-teal-700 text-white font-semibold py-2 px-4 rounded-md">Guardar</button>
+       <a href="{% url 'gestor_tareas:lista_tareas' %}" class="bg-gray-200 text-[#0F172A] py-2 px-4 rounded-md">Cancelar</a>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/gestor_tareas/templates/gestor_tareas/lista_tareas.html
+++ b/gestor_tareas/templates/gestor_tareas/lista_tareas.html
@@ -3,104 +3,114 @@
 {% block title %}Lista de Tareas{% endblock %}
 
 {% block content %}
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex gap-4 items-start">
-    <aside class="w-64 bg-slate-800 rounded-lg shadow-xl p-4 text-sm">
-        <h2 class="text-center font-bold mb-2">Notas</h2>
-        <form id="noteForm" class="flex gap-2">
-            <input id="noteInput" type="text" class="flex-grow bg-slate-700 p-2 rounded focus:outline-none focus:ring-2 focus:ring-cyan-500" placeholder="Nueva nota...">
-            <button type="submit" class="bg-green-600 hover:bg-green-700 text-white px-2 rounded">+</button>
-        </form>
-        <ul id="notesList" class="mt-4 space-y-2"></ul>
-    </aside>
-    <div class="flex-1">
-    <header class="flex flex-col sm:flex-row justify-between items-center mb-6 gap-4">
-        <h1 class="text-3xl font-bold text-white text-center sm:text-left">
-            Gestor de <span class="text-cyan-400">Tareas</span>
-        </h1>
-        <a href="{% url 'gestor_tareas:agregar_tarea_voz' %}" class="w-full sm:w-auto bg-cyan-600 hover:bg-cyan-700 text-white font-bold py-2 px-4 rounded-lg shadow-lg transition-transform transform hover:scale-105 flex items-center justify-center gap-2">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-              <path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd" />
-            </svg>
-            Agregar Tarea
-        </a>
-    </header>
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <form id="filtersForm" method="get" class="w-full">
+        <header class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-4 gap-4">
+            <div class="flex flex-col gap-1 w-full sm:w-auto">
+                <nav class="text-sm text-gray-500">Dashboard / <span class="text-gray-700">Tareas</span></nav>
+                <h1 class="text-2xl font-bold text-[#0F172A]">Gestor de <span class="text-teal-600">Tareas</span></h1>
+            </div>
+            <div class="flex items-center gap-2 w-full sm:w-auto">
+                <input name="q" id="searchInput" type="search" placeholder="Buscar..." value="{{ filtros.q }}" class="flex-grow sm:flex-none border border-[#E5E7EB] rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-teal-500" />
+                <button type="button" id="notesToggle" class="bg-gray-200 text-[#0F172A] px-4 py-2 rounded-md">Notas</button>
+                <a href="{% url 'gestor_tareas:agregar_tarea_voz' %}" class="bg-teal-600 hover:bg-teal-700 text-white font-bold py-2 px-4 rounded-md">+ Nueva tarea</a>
+            </div>
+        </header>
 
-        <div id="status-message" class="mb-4 text-center font-medium h-6 transition-opacity duration-300"></div>
+        <div class="flex flex-wrap gap-2 mb-4">
+            <select name="estado" onchange="this.form.submit()" class="px-3 py-1 rounded-full bg-gray-200 text-sm">
+                <option value="">Estado</option>
+                {% for value, label in estados_posibles %}
+                <option value="{{ value }}" {% if filtros.estado == value %}selected{% endif %}>{{ label }}</option>
+                {% endfor %}
+            </select>
+            <select name="prioridad" onchange="this.form.submit()" class="px-3 py-1 rounded-full bg-gray-200 text-sm">
+                <option value="">Prioridad</option>
+                {% for p in prioridades_posibles %}
+                <option value="{{ p }}" {% if filtros.prioridad == p %}selected{% endif %}>{{ p }}</option>
+                {% endfor %}
+            </select>
+            <select name="tipo" onchange="this.form.submit()" class="px-3 py-1 rounded-full bg-gray-200 text-sm">
+                <option value="">Tipo</option>
+                {% for t in tipos_posibles %}
+                <option value="{{ t }}" {% if filtros.tipo == t %}selected{% endif %}>{{ t }}</option>
+                {% endfor %}
+            </select>
+        </div>
+    </form>
 
-        <div class="bg-slate-800 rounded-lg shadow-xl overflow-hidden">
-            <div class="overflow-x-auto">
-                <table class="w-full text-sm text-left table-auto">
-                    <thead class="text-xs text-slate-400 uppercase">
-                    <tr>
-                        <th class="px-4 py-3">Orden</th>
-                        <th class="px-4 py-3">Recibido</th>
-                        <th class="px-4 py-3">Cliente / Teléfono</th>
-                        <th class="px-4 py-3">Tipo</th>
-                        <th class="px-4 py-3">Descripción</th>
-                        <th class="px-4 py-3">Estado</th>
-                        <th class="px-4 py-3">Prioridad</th>
-                        <th class="px-4 py-3">Acciones</th>
-                    </tr>
+    <div id="status-message" class="mb-4 text-center font-medium h-6 transition-opacity duration-300"></div>
+
+    <div class="bg-white rounded-lg shadow overflow-hidden">
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm text-left table-auto">
+                <thead class="text-xs text-gray-500 uppercase bg-gray-50">
+                <tr>
+                    <th class="px-4 py-3">Orden</th>
+                    <th class="px-4 py-3">Recibido</th>
+                    <th class="px-4 py-3">Cliente</th>
+                    <th class="px-4 py-3">Tipo</th>
+                    <th class="px-4 py-3">Tarea</th>
+                    <th class="px-4 py-3">Estado</th>
+                    <th class="px-4 py-3">Prioridad</th>
+                    <th class="px-4 py-3 text-right">Acciones</th>
+                    <th class="px-4 py-3">Mover</th>
+                </tr>
                 </thead>
-                    <tbody id="tareas-body" class="divide-y divide-slate-700">
-                        {% for tarea in tareas %}
-                        <tr id="tarea-row-{{ tarea.id }}" draggable="true" class="hover:bg-slate-700/50 transition-colors duration-200 {% if tarea.estado == 'Recibido' %}bg-blue-900/60{% elif tarea.estado == 'En Proceso' %}bg-yellow-900/60{% elif tarea.estado == 'Completado' %}bg-green-900/60 completed-row{% endif %}">
-
-                        <td class="px-4 py-3 text-xl font-bold text-white">{{ tarea.orden|default:0 }}</td>
-
+                <tbody id="tareas-body" class="divide-y divide-[#E5E7EB]">
+                    {% for tarea in tareas %}
+                    <tr id="tarea-row-{{ tarea.id }}" class="hover:bg-gray-50 transition-colors" draggable="true" data-id="{{ tarea.id }}">
+                        <td class="px-4 py-3 text-lg font-semibold orden-cell">{{ tarea.orden|default:0 }}</td>
                         <td class="px-4 py-3">{{ tarea.dias_desde_recibido }}</td>
-
-                        <td class="px-4 py-3 font-medium text-white">
-                            {{ tarea.cliente }}
-                            {% if tarea.telefono %}
-                                <br><span class="text-xs text-slate-400">{{ tarea.telefono }}</span>
-                            {% endif %}
+                        <td class="px-4 py-3">
+                            {{ tarea.cliente }}{% if tarea.telefono %} · <a href="https://wa.me/{{ tarea.telefono|cut:' '|cut:'-' }}" target="_blank" class="text-teal-600 hover:underline">{{ tarea.telefono }}</a>{% endif %}
                         </td>
-                        
                         <td class="px-4 py-3">{{ tarea.tipo.nombre|default:"--" }}</td>
-                        <td class="px-4 py-3 text-slate-400 italic">
+                        <td class="px-4 py-3 text-gray-600">
                             {% with tarea.descripcion|wordcount as cant_palabras %}
                                 <span id="desc-short-{{ tarea.id }}">
-                                    {{ tarea.descripcion|truncatewords:10|default:"--" }}
-                                    {% if cant_palabras > 10 %}
-                                        <a href="#" class="text-cyan-400 ml-1" onclick="toggleDescripcion({{ tarea.id }}); return false;">Ver más</a>
+                                    {{ tarea.descripcion|truncatewords:8|default:"--" }}
+                                    {% if cant_palabras > 8 %}
+                                        <a href="#" class="text-teal-600 ml-1" onclick="toggleDescripcion({{ tarea.id }}); return false;">▾</a>
                                     {% endif %}
                                 </span>
-                                {% if cant_palabras > 10 %}
+                                {% if cant_palabras > 8 %}
                                 <span id="desc-full-{{ tarea.id }}" class="hidden">
                                     {{ tarea.descripcion }}
-                                    <a href="#" class="text-cyan-400 ml-1" onclick="toggleDescripcion({{ tarea.id }}); return false;">Ver menos</a>
+                                    <a href="#" class="text-teal-600 ml-1" onclick="toggleDescripcion({{ tarea.id }}); return false;">▴</a>
                                 </span>
                                 {% endif %}
                             {% endwith %}
                         </td>
                         <td class="px-4 py-3">
-                            <select onchange="actualizarEstado(this)" data-task-id="{{ tarea.id }}" class="bg-slate-700 border border-slate-600 rounded-md p-1 text-xs focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500">
+                            <select onchange="actualizarEstado(this)" data-task-id="{{ tarea.id }}" class="estado-select text-xs font-medium rounded-full px-2 py-1 focus:outline-none">
                                 {% for value, label in estados_posibles %}
                                 <option value="{{ value }}" {% if tarea.estado == value %}selected{% endif %}>{{ label }}</option>
                                 {% endfor %}
                             </select>
                         </td>
                         <td class="px-4 py-3">
-                          <span class="px-2 py-1 font-semibold leading-tight rounded-full text-xs
-                            {% if tarea.prioridad == 'Urgente' %} bg-red-700 text-red-100 {% else %} bg-sky-700 text-sky-100 {% endif %}">
+                          <span class="px-2 py-1 rounded-full text-xs font-medium text-white
+                            {% if tarea.prioridad == 'Urgente' %} bg-red-500
+                            {% elif tarea.prioridad == 'Alta' %} bg-orange-400
+                            {% elif tarea.prioridad == 'Baja' %} bg-gray-400
+                            {% else %} bg-blue-500 {% endif %}">
                             {{ tarea.prioridad }}
                           </span>
                         </td>
-                        <td class="px-4 py-3 whitespace-nowrap">
-                            <a href="{% url 'gestor_tareas:editar_tarea' tarea.id %}" class="text-yellow-400 hover:text-yellow-300 mr-3 font-medium">Editar</a>
-                            <button onclick="ocultarTarea({{ tarea.id }})" class="text-red-500 hover:text-red-400 font-medium">Ocultar</button>
+                        <td class="px-4 py-3 whitespace-nowrap text-right">
+                            <a href="{% url 'gestor_tareas:editar_tarea' tarea.id %}" class="text-teal-600 hover:underline mr-3">Editar</a>
+                            <button onclick="ocultarTarea({{ tarea.id }})" class="text-red-600 hover:underline">Archivar</button>
                         </td>
-
+                        <td class="px-4 py-3 text-gray-400 cursor-move text-center">☰</td>
                     </tr>
-                        {% empty %}
-                        <tr>
-                            <td colspan="8" class="text-center py-10 text-slate-500">No hay tareas visibles. ¡Agrega la primera!</td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
+                    {% empty %}
+                    <tr>
+                        <td colspan="9" class="text-center py-10 text-gray-500">No hay tareas visibles. ¡Agrega la primera!</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         </div>
     </div>
 </div>
@@ -108,14 +118,37 @@
 
 {% block extra_scripts %}
 <script>
-    // Función para actualizar el estado de una tarea desde el menú desplegable
+    const searchInput = document.getElementById('searchInput');
+    document.addEventListener('keydown', (e) => {
+        if (e.key === '/' && document.activeElement !== searchInput) {
+            e.preventDefault();
+            searchInput.focus();
+        }
+        if (e.key === 'n' && e.target.tagName !== 'INPUT' && e.target.tagName !== 'TEXTAREA') {
+            window.location.href = "{% url 'gestor_tareas:agregar_tarea_voz' %}";
+        }
+    });
+
+    const stateColors = {
+        'Recibido': 'bg-blue-500 text-white',
+        'En Proceso': 'bg-amber-500 text-white',
+        'Completado': 'bg-green-500 text-white',
+        'Bloqueado': 'bg-red-500 text-white',
+        'En espera': 'bg-gray-500 text-white'
+    };
+    function styleEstado(select){
+        const base = 'estado-select text-xs font-medium rounded-full px-2 py-1 focus:outline-none';
+        select.className = base + ' ' + (stateColors[select.value] || 'bg-gray-200 text-gray-800');
+    }
+    document.querySelectorAll('.estado-select').forEach(styleEstado);
+
     async function actualizarEstado(selectElement) {
         const tareaId = selectElement.dataset.taskId;
         const nuevoEstado = selectElement.value;
         const statusBox = document.getElementById('status-message');
 
         statusBox.textContent = 'Actualizando...';
-        statusBox.className = 'mb-4 text-center font-medium text-yellow-300';
+        statusBox.className = 'mb-4 text-center font-medium text-[#F59E0B]';
 
         try {
             const response = await fetch("{% url 'gestor_tareas:actualizar_estado' %}", {
@@ -128,7 +161,8 @@
             if (result.status !== 'success') throw new Error(result.message);
 
             statusBox.textContent = `✅ ${result.message}`;
-            statusBox.className = 'mb-4 text-center font-medium text-green-300';
+            statusBox.className = 'mb-4 text-center font-medium text-[#10B981]';
+            styleEstado(selectElement);
 
             const row = document.getElementById(`tarea-row-${tareaId}`);
             if (nuevoEstado === 'Completado') {
@@ -139,22 +173,19 @@
 
         } catch (error) {
             statusBox.textContent = `❌ Error: ${error.message}`;
-            statusBox.className = 'mb-4 text-center font-medium text-red-300';
+            statusBox.className = 'mb-4 text-center font-medium text-[#EF4444]';
         } finally {
             setTimeout(() => { statusBox.textContent = ''; }, 3000);
         }
     }
 
-    // Función para ocultar (archivar) una tarea
     async function ocultarTarea(tareaId) {
-        if (!confirm(`¿Estás seguro de que quieres archivar la tarea #${tareaId}?`)) {
-            return;
-        }
+        if (!confirm(`¿Archivar la tarea #${tareaId}?`)) { return; }
 
         const statusBox = document.getElementById('status-message');
         statusBox.textContent = 'Archivando...';
-        statusBox.className = 'mb-4 text-center font-medium text-yellow-300';
-        
+        statusBox.className = 'mb-4 text-center font-medium text-[#F59E0B]';
+
         try {
             const response = await fetch(`/tareas/ocultar/${tareaId}/`, {
                 method: 'POST',
@@ -165,9 +196,8 @@
             if (result.status !== 'success') throw new Error(result.message);
 
             statusBox.textContent = `✅ ${result.message}`;
-            statusBox.className = 'mb-4 text-center font-medium text-green-300';
+            statusBox.className = 'mb-4 text-center font-medium text-[#10B981]';
 
-            // Ocultar la fila de la tabla para feedback inmediato con una animación
             const row = document.getElementById(`tarea-row-${tareaId}`);
             if (row) {
                 row.style.transition = 'opacity 0.5s ease-out';
@@ -177,13 +207,12 @@
 
         } catch (error) {
             statusBox.textContent = `❌ Error: ${error.message}`;
-            statusBox.className = 'mb-4 text-center font-medium text-red-300';
+            statusBox.className = 'mb-4 text-center font-medium text-[#EF4444]';
         } finally {
             setTimeout(() => { statusBox.textContent = ''; }, 3000);
         }
     }
 
-    // Alternar la descripción completa o resumida
     function toggleDescripcion(id) {
         const shortEl = document.getElementById(`desc-short-${id}`);
         const fullEl = document.getElementById(`desc-full-${id}`);
@@ -193,42 +222,33 @@
         }
     }
 
-    // --- Drag and drop para reordenar tareas ---
-    const tbody = document.getElementById('tareas-body');
-    let draggedRow = null;
-    tbody.addEventListener('dragstart', (e) => {
-        draggedRow = e.target.closest('tr');
-        e.dataTransfer.effectAllowed = 'move';
+    const notesDrawer = document.createElement('div');
+    notesDrawer.id = 'notesDrawer';
+    notesDrawer.className = 'fixed top-0 right-0 h-full w-full max-w-xs sm:w-80 bg-white shadow-lg transform translate-x-full transition-transform z-50';
+    notesDrawer.innerHTML = `
+        <div class="p-4 border-b border-[#E5E7EB] flex justify-between items-center">
+            <h2 class="font-bold">Notas</h2>
+            <button id="closeNotes" class="text-gray-500">✕</button>
+        </div>
+        <div class="p-4 text-sm overflow-y-auto h-full">
+            <form id="noteForm" class="flex gap-2">
+                <input id="noteInput" type="text" class="flex-grow border border-[#E5E7EB] p-2 rounded focus:outline-none" placeholder="Nueva nota...">
+                <button type="submit" class="bg-teal-600 text-white px-2 rounded">+</button>
+            </form>
+            <ul id="notesList" class="mt-4 space-y-2"></ul>
+        </div>`;
+    document.body.appendChild(notesDrawer);
+    document.body.classList.add('overflow-x-hidden');
+
+    document.getElementById('notesToggle').addEventListener('click', () => {
+        notesDrawer.classList.remove('translate-x-full');
     });
-    tbody.addEventListener('dragover', (e) => {
-        e.preventDefault();
-        const target = e.target.closest('tr');
-        if (!target || target === draggedRow) return;
-        const rect = target.getBoundingClientRect();
-        const next = (e.clientY - rect.top) / (rect.bottom - rect.top) > 0.5;
-        tbody.insertBefore(draggedRow, next ? target.nextSibling : target);
-    });
-    tbody.addEventListener('drop', (e) => {
-        e.preventDefault();
-        actualizarOrdenesServidor();
+    document.body.addEventListener('click', (e) => {
+        if (e.target.id === 'closeNotes') {
+            notesDrawer.classList.add('translate-x-full');
+        }
     });
 
-    async function actualizarOrdenesServidor(){
-        const rows = [...tbody.querySelectorAll('tr')];
-        const ordenes = [];
-        rows.forEach((row, idx) => {
-            row.querySelector('td').textContent = idx + 1;
-            const id = row.id.split('-')[2];
-            ordenes.push({id: id, orden: idx + 1});
-        });
-        await fetch("{% url 'gestor_tareas:reordenar_tareas' %}", {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': '{{ csrf_token }}' },
-            body: JSON.stringify({ ordenes })
-        });
-    }
-
-    // --- Sidebar de notas ---
     const notesList = document.getElementById('notesList');
     const noteForm = document.getElementById('noteForm');
     const noteInput = document.getElementById('noteInput');
@@ -238,7 +258,7 @@
         notesList.innerHTML = '';
         notes.forEach((note, idx) => {
             const li = document.createElement('li');
-            li.className = 'relative bg-slate-700 p-2 rounded hover:bg-slate-600';
+            li.className = 'relative bg-gray-100 p-2 rounded hover:bg-gray-200';
             const span = document.createElement('span');
             span.textContent = note;
             span.addEventListener('dblclick', () => {
@@ -251,7 +271,7 @@
             });
             const btn = document.createElement('button');
             btn.textContent = 'x';
-            btn.className = 'absolute top-1 right-1 text-red-300 hover:text-red-200';
+            btn.className = 'absolute top-1 right-1 text-red-500';
             btn.addEventListener('click', () => {
                 notes.splice(idx,1);
                 localStorage.setItem('tareasNotas', JSON.stringify(notes));
@@ -275,5 +295,57 @@
     });
 
     loadNotes();
+
+    // --- Drag and drop para reordenar ---
+    let dragged;
+    document.querySelectorAll('#tareas-body tr').forEach(row => {
+        row.addEventListener('dragstart', e => {
+            dragged = row;
+            e.dataTransfer.effectAllowed = 'move';
+            row.classList.add('opacity-50');
+        });
+        row.addEventListener('dragend', () => {
+            row.classList.remove('opacity-50');
+        });
+        row.addEventListener('dragover', e => {
+            e.preventDefault();
+            const target = e.currentTarget;
+            if (dragged === target) return;
+            const tbody = document.getElementById('tareas-body');
+            const bounds = target.getBoundingClientRect();
+            const offset = e.clientY - bounds.top;
+            const midpoint = bounds.height / 2;
+            if (offset > midpoint) {
+                tbody.insertBefore(dragged, target.nextSibling);
+            } else {
+                tbody.insertBefore(dragged, target);
+            }
+        });
+        row.addEventListener('dragenter', () => {
+            if (row !== dragged) row.classList.add('bg-teal-50');
+        });
+        row.addEventListener('dragleave', () => {
+            row.classList.remove('bg-teal-50');
+        });
+        row.addEventListener('drop', e => {
+            e.preventDefault();
+            row.classList.remove('bg-teal-50');
+            actualizarOrdenServidor();
+        });
+    });
+
+    function actualizarOrdenServidor(){
+        const ordenes = [];
+        document.querySelectorAll('#tareas-body tr').forEach((row, idx) => {
+            ordenes.push({id: row.dataset.id, orden: idx + 1});
+            const cell = row.querySelector('.orden-cell');
+            if (cell) cell.textContent = idx + 1;
+        });
+        fetch("{% url 'gestor_tareas:reordenar_tareas' %}", {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': '{{ csrf_token }}' },
+            body: JSON.stringify({ordenes})
+        });
+    }
 </script>
 {% endblock %}

--- a/interfaz/templates/interfaz/dashboard.html
+++ b/interfaz/templates/interfaz/dashboard.html
@@ -4,79 +4,83 @@
 {% block title %}Dashboard Contable{% endblock %}
 
 {% block content %}
-<div class="max-w-5xl mx-auto px-4">
-  <header class="text-center mb-8">
-    <h1 class="text-3xl font-bold text-white">Resumen de <span class="text-green-400">Contabilidad</span></h1>
-    <p class="text-2xl mt-2">Saldo total: <span class="text-green-400">{{ saldo_total_general|moneda }}</span></p>
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+  <header class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8 gap-4">
+    <div class="flex flex-col gap-1">
+      <nav class="text-sm text-gray-500">Dashboard / <span class="text-gray-700">Contabilidad</span></nav>
+      <h1 class="text-3xl font-bold text-[#0F172A]">Resumen de <span class="text-teal-600">Contabilidad</span></h1>
+      <p class="text-2xl mt-2 text-[#0F172A]">Saldo total: <span class="text-green-600">{{ saldo_total_general|moneda }}</span></p>
+    </div>
   </header>
 
   <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
-    <div class="bg-slate-800 rounded-lg p-4">
-      <h2 class="text-center font-semibold text-slate-400 mb-2">Semana</h2>
-        <p class="text-blue-400">Ingresos: {{ totales_semana.ingresos|moneda }}</p>
-        <p class="text-red-400">Egresos: {{ totales_semana.egresos|moneda }}</p>
+    <div class="bg-white rounded-lg p-4 shadow">
+      <h2 class="text-center font-semibold text-gray-500 mb-2">Semana</h2>
+        <p class="text-blue-600">Ingresos: {{ totales_semana.ingresos|moneda }}</p>
+        <p class="text-red-600">Egresos: {{ totales_semana.egresos|moneda }}</p>
         <p class="font-bold">Saldo: {{ totales_semana.saldo|moneda }}</p>
     </div>
-    <div class="bg-slate-800 rounded-lg p-4">
-      <h2 class="text-center font-semibold text-slate-400 mb-2">Mes</h2>
-        <p class="text-blue-400">Ingresos: {{ totales_mes.ingresos|moneda }}</p>
-        <p class="text-red-400">Egresos: {{ totales_mes.egresos|moneda }}</p>
+    <div class="bg-white rounded-lg p-4 shadow">
+      <h2 class="text-center font-semibold text-gray-500 mb-2">Mes</h2>
+        <p class="text-blue-600">Ingresos: {{ totales_mes.ingresos|moneda }}</p>
+        <p class="text-red-600">Egresos: {{ totales_mes.egresos|moneda }}</p>
         <p class="font-bold">Saldo: {{ totales_mes.saldo|moneda }}</p>
     </div>
-    <div class="bg-slate-800 rounded-lg p-4">
-      <h2 class="text-center font-semibold text-slate-400 mb-2">Año</h2>
-        <p class="text-blue-400">Ingresos: {{ totales_anio.ingresos|moneda }}</p>
-        <p class="text-red-400">Egresos: {{ totales_anio.egresos|moneda }}</p>
+    <div class="bg-white rounded-lg p-4 shadow">
+      <h2 class="text-center font-semibold text-gray-500 mb-2">Año</h2>
+        <p class="text-blue-600">Ingresos: {{ totales_anio.ingresos|moneda }}</p>
+        <p class="text-red-600">Egresos: {{ totales_anio.egresos|moneda }}</p>
         <p class="font-bold">Saldo: {{ totales_anio.saldo|moneda }}</p>
     </div>
   </div>
 
-  <h2 class="text-xl font-semibold mb-4">Resumen por Cuenta</h2>
+  <h2 class="text-xl font-semibold mb-4 text-[#0F172A]">Resumen por Cuenta</h2>
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
     {% for c in cuentas_data %}
-    <div class="bg-slate-800 rounded-lg p-4 space-y-2 text-center">
+    <div class="bg-white rounded-lg p-4 space-y-2 text-center shadow">
       <h3 class="font-bold">
-        <a href="{% url 'interfaz:movimientos_cuenta' c.cuenta.id %}"
-           class="text-cyan-400 hover:underline">{{ c.cuenta.nombre }}</a>
+        <a href="{% url 'interfaz:movimientos_cuenta' c.cuenta.id %}" class="text-teal-600 hover:underline">{{ c.cuenta.nombre }}</a>
       </h3>
-      <p class="text-2xl font-bold text-green-400">{{ c.saldo_actual|moneda }}</p>
-      <p class="text-xl text-blue-400">Ingreso mensual: {{ c.totales_mes.ingresos|moneda }}</p>
+      <p class="text-2xl font-bold text-green-600">{{ c.saldo_actual|moneda }}</p>
+      <p class="text-xl text-blue-600">Ingreso mensual: {{ c.totales_mes.ingresos|moneda }}</p>
     </div>
     {% empty %}
-    <p class="text-slate-500">Sin cuentas registradas.</p>
+    <p class="text-gray-500">Sin cuentas registradas.</p>
     {% endfor %}
   </div>
-  <h2 class="text-xl font-semibold mb-4">Últimos 10 registros</h2>
-  <div class="bg-slate-800 rounded-lg overflow-hidden shadow-xl">
+  <h2 class="text-xl font-semibold mb-4 text-[#0F172A]">Últimos 10 registros</h2>
+  <div class="bg-white rounded-lg overflow-hidden shadow">
+    <div class="overflow-x-auto">
     <table class="w-full text-sm">
-      <thead class="text-slate-400">
+      <thead class="text-gray-500">
         <tr>
           <th class="px-4 py-2">Fecha</th>
           <th class="px-4 py-2">Descripción</th>
-          <th class="px-4 py-2 text-blue-400">Ingresos</th>
-          <th class="px-4 py-2 text-red-400">Egresos</th>
+          <th class="px-4 py-2 text-blue-600">Ingresos</th>
+          <th class="px-4 py-2 text-red-600">Egresos</th>
           <th class="px-4 py-2">Cliente</th>
           <th class="px-4 py-2">Acciones</th>
         </tr>
       </thead>
-      <tbody class="divide-y divide-slate-700">
+      <tbody class="divide-y divide-[#E5E7EB]">
         {% for r in registros_recientes %}
         <tr>
           <td class="px-4 py-2">{{ r.fecha|date:'Y-m-d' }}</td>
           <td class="px-4 py-2">{{ r.descripcion }}</td>
-            <td class="px-4 py-2 text-blue-400">{{ r.ingresos|moneda }}</td>
-            <td class="px-4 py-2 text-red-400">{{ r.egresos|moneda }}</td>
+            <td class="px-4 py-2 text-blue-600">{{ r.ingresos|moneda }}</td>
+            <td class="px-4 py-2 text-red-600">{{ r.egresos|moneda }}</td>
           <td class="px-4 py-2">{{ r.cliente.nombre|default:'--' }}</td>
           <td class="px-4 py-2 whitespace-nowrap">
-            <a href="{% url 'interfaz:editar_registro' r.id %}" class="text-yellow-400 mr-2">Editar</a>
-            <button onclick="eliminarRegistro({{ r.id }})" class="text-red-500">Eliminar</button>
+            <a href="{% url 'interfaz:editar_registro' r.id %}" class="text-teal-600 mr-2">Editar</a>
+            <button onclick="eliminarRegistro({{ r.id }})" class="text-red-600">Eliminar</button>
           </td>
         </tr>
         {% empty %}
-        <tr><td colspan="6" class="text-center py-4 text-slate-500">Sin registros</td></tr>
+        <tr><td colspan="6" class="text-center py-4 text-gray-500">Sin registros</td></tr>
         {% endfor %}
       </tbody>
     </table>
+    </div>
   </div>
   <form id="delete-form" method="post" class="hidden">{% csrf_token %}</form>
 </div>

--- a/interfaz/templates/interfaz/editar_registro.html
+++ b/interfaz/templates/interfaz/editar_registro.html
@@ -5,27 +5,27 @@
 {% block content %}
 <div class="max-w-md mx-auto px-4">
   <header class="text-center mb-6">
-    <h1 class="text-2xl font-bold text-white">Editar Registro</h1>
-    <a href="{{ return_url }}" class="text-cyan-400 hover:text-cyan-300">← Volver</a>
+    <h1 class="text-2xl font-bold text-[#0F172A]">Editar Registro</h1>
+    <a href="{{ return_url }}" class="text-teal-600 hover:underline">← Volver</a>
   </header>
-  <form method="post" class="bg-slate-800 rounded-lg p-6 space-y-4">
+  <form method="post" class="bg-white rounded-lg p-6 space-y-4 shadow">
     {% csrf_token %}
     <input type="hidden" name="next" value="{{ return_url }}">
     <div>
-      <label for="fecha" class="block mb-1 text-slate-400 font-medium">Fecha</label>
-      <input type="date" id="fecha" name="fecha" value="{{ registro.fecha|date:'Y-m-d' }}" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-cyan-500" required>
+      <label for="fecha" class="block mb-1 text-gray-700 font-medium">Fecha</label>
+      <input type="date" id="fecha" name="fecha" value="{{ registro.fecha|date:'Y-m-d' }}" class="w-full border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-teal-500" required>
     </div>
     <div>
-      <label for="descripcion" class="block mb-1 text-slate-400 font-medium">Descripción</label>
-      <input type="text" id="descripcion" name="descripcion" value="{{ registro.descripcion }}" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-cyan-500">
+      <label for="descripcion" class="block mb-1 text-gray-700 font-medium">Descripción</label>
+      <input type="text" id="descripcion" name="descripcion" value="{{ registro.descripcion }}" class="w-full border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-teal-500">
     </div>
     <div>
-      <label for="cliente" class="block mb-1 text-slate-400 font-medium">Cliente</label>
-      <input type="text" id="cliente" name="cliente" value="{{ registro.cliente.nombre|default:'' }}" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3">
+      <label for="cliente" class="block mb-1 text-gray-700 font-medium">Cliente</label>
+      <input type="text" id="cliente" name="cliente" value="{{ registro.cliente.nombre|default:'' }}" class="w-full border border-gray-300 rounded-md py-2 px-3">
     </div>
     <div>
-      <label for="categoria" class="block mb-1 text-slate-400 font-medium">Categoría</label>
-      <select id="categoria" name="categoria" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-cyan-500">
+      <label for="categoria" class="block mb-1 text-gray-700 font-medium">Categoría</label>
+      <select id="categoria" name="categoria" class="w-full border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-teal-500">
         <option value="">--</option>
         {% for c in categorias %}
         <option value="{{ c.nombre }}" {% if registro.categoria and registro.categoria.id == c.id %}selected{% endif %}>{{ c.nombre }}</option>
@@ -33,8 +33,8 @@
       </select>
     </div>
     <div>
-      <label for="cuenta" class="block mb-1 text-slate-400 font-medium">Cuenta</label>
-      <select id="cuenta" name="cuenta" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-cyan-500">
+      <label for="cuenta" class="block mb-1 text-gray-700 font-medium">Cuenta</label>
+      <select id="cuenta" name="cuenta" class="w-full border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-teal-500">
         <option value="">--</option>
         {% for c in cuentas %}
         <option value="{{ c.nombre }}" {% if registro.cuenta and registro.cuenta.id == c.id %}selected{% endif %}>{{ c.nombre }}</option>
@@ -42,15 +42,15 @@
       </select>
     </div>
     <div>
-      <label for="egresos" class="block mb-1 text-slate-400 font-medium">Egresos</label>
-      <input type="number" step="0.01" id="egresos" name="egresos" value="{{ registro.egresos }}" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3">
+      <label for="egresos" class="block mb-1 text-gray-700 font-medium">Egresos</label>
+      <input type="number" step="0.01" id="egresos" name="egresos" value="{{ registro.egresos }}" class="w-full border border-gray-300 rounded-md py-2 px-3">
     </div>
     <div>
-      <label for="ingresos" class="block mb-1 text-slate-400 font-medium">Ingresos</label>
-      <input type="number" step="0.01" id="ingresos" name="ingresos" value="{{ registro.ingresos }}" class="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3">
+      <label for="ingresos" class="block mb-1 text-gray-700 font-medium">Ingresos</label>
+      <input type="number" step="0.01" id="ingresos" name="ingresos" value="{{ registro.ingresos }}" class="w-full border border-gray-300 rounded-md py-2 px-3">
     </div>
     <div class="text-center pt-4">
-      <button type="submit" class="bg-green-600 hover:bg-green-700 py-2 px-6 rounded-lg font-semibold">Guardar</button>
+      <button type="submit" class="bg-teal-600 hover:bg-teal-700 py-2 px-6 rounded-lg font-semibold text-white">Guardar</button>
     </div>
   </form>
 </div>

--- a/interfaz/templates/interfaz/movimientos_cuenta.html
+++ b/interfaz/templates/interfaz/movimientos_cuenta.html
@@ -6,43 +6,48 @@
 {% block title %}Movimientos de {{ cuenta.nombre }}{% endblock %}
 
 {% block content %}
-<div class="max-w-5xl mx-auto px-4">
-  <header class="text-center mb-6">
-    <h1 class="text-2xl font-bold text-white">Movimientos de {{ cuenta.nombre }}</h1>
-    <a href="{% url 'interfaz:dashboard' %}" class="text-cyan-400 hover:text-cyan-300">← Volver al dashboard</a>
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+  <header class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6 gap-4">
+    <div class="flex flex-col gap-1">
+      <nav class="text-sm text-gray-500">Contabilidad / <span class="text-gray-700">Movimientos</span></nav>
+      <h1 class="text-2xl font-bold text-[#0F172A]">Movimientos de <span class="text-teal-600">{{ cuenta.nombre }}</span></h1>
+    </div>
+    <a href="{% url 'interfaz:dashboard' %}" class="text-teal-600 hover:underline">← Volver al dashboard</a>
   </header>
-  <div class="bg-slate-800 rounded-lg overflow-hidden shadow-xl">
+  <div class="bg-white rounded-lg overflow-hidden shadow">
+    <div class="overflow-x-auto">
     <table class="w-full text-sm">
-      <thead class="text-slate-400">
+      <thead class="text-gray-500">
         <tr>
           <th class="px-4 py-2">Fecha</th>
           <th class="px-4 py-2">Descripción</th>
           <th class="px-4 py-2">Categoría</th>
-          <th class="px-4 py-2 text-blue-400">Ingresos</th>
-          <th class="px-4 py-2 text-red-400">Egresos</th>
+          <th class="px-4 py-2 text-blue-600">Ingresos</th>
+          <th class="px-4 py-2 text-red-600">Egresos</th>
           <th class="px-4 py-2">Cliente</th>
           <th class="px-4 py-2">Acciones</th>
         </tr>
       </thead>
-      <tbody class="divide-y divide-slate-700">
+      <tbody class="divide-y divide-[#E5E7EB]">
         {% for r in registros %}
         <tr>
           <td class="px-4 py-2">{{ r.fecha|date:'Y-m-d' }}</td>
           <td class="px-4 py-2">{{ r.descripcion }}</td>
           <td class="px-4 py-2">{{ r.categoria.nombre|default:'--' }}</td>
-          <td class="px-4 py-2 text-blue-400">{{ r.ingresos|moneda }}</td>
-          <td class="px-4 py-2 text-red-400">{{ r.egresos|moneda }}</td>
+          <td class="px-4 py-2 text-blue-600">{{ r.ingresos|moneda }}</td>
+          <td class="px-4 py-2 text-red-600">{{ r.egresos|moneda }}</td>
           <td class="px-4 py-2">{{ r.cliente.nombre|default:'--' }}</td>
           <td class="px-4 py-2 whitespace-nowrap">
-            <a href="{% url 'interfaz:editar_registro' r.id %}?next={% url 'interfaz:movimientos_cuenta' cuenta.id %}" class="text-yellow-400 mr-2">Editar</a>
-            <button onclick="eliminarRegistro({{ r.id }})" class="text-red-500">Eliminar</button>
+            <a href="{% url 'interfaz:editar_registro' r.id %}?next={% url 'interfaz:movimientos_cuenta' cuenta.id %}" class="text-teal-600 mr-2">Editar</a>
+            <button onclick="eliminarRegistro({{ r.id }})" class="text-red-600">Eliminar</button>
           </td>
         </tr>
         {% empty %}
-        <tr><td colspan="7" class="text-center py-4 text-slate-500">Sin registros</td></tr>
+        <tr><td colspan="7" class="text-center py-4 text-gray-500">Sin registros</td></tr>
         {% endfor %}
       </tbody>
     </table>
+    </div>
   </div>
   <form id="delete-form" method="post" class="hidden">{% csrf_token %}</form>
 </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,35 +12,35 @@
         body { font-family: 'Inter', sans-serif; -webkit-tap-highlight-color: transparent; }
         .pulse { animation: pulse-animation 1.6s infinite; }
         @keyframes pulse-animation { 0% { box-shadow: 0 0 0 0 rgba(14, 165, 233, 0.7); } 100% { box-shadow: 0 0 0 25px rgba(14, 165, 233, 0); } }
-        .ts-control { background-color: #334155 !important; border-color: #475569 !important; color: #fff !important; }
-        .ts-dropdown { background-color: #334155 !important; border-color: #475569 !important; }
-        .ts-dropdown .option, .ts-dropdown .create { color: #cbd5e1 !important; }
-        .ts-dropdown .active { background-color: #0ea5e9 !important; color: #fff !important; }
-        .completed-row td { text-decoration: line-through; color: #94a3b8; }
+        .ts-control { background-color: #ffffff !important; border-color: #E5E7EB !important; color: #0F172A !important; }
+        .ts-dropdown { background-color: #ffffff !important; border-color: #E5E7EB !important; }
+        .ts-dropdown .option, .ts-dropdown .create { color: #0F172A !important; }
+        .ts-dropdown .active { background-color: #14B8A6 !important; color: #ffffff !important; }
+        .completed-row td { text-decoration: line-through; color: #9CA3AF; }
     </style>
     {% block extra_styles %}{% endblock %}
 </head>
-<body class="bg-gradient-to-b from-slate-900 to-slate-800 text-white min-h-screen">
+<body class="bg-[#F6F7F9] text-[#0F172A] min-h-screen">
     <!-- BARRA DE NAVEGACIÓN RESPONSIVA -->
-    <nav class="bg-slate-800/60 backdrop-blur shadow-lg sticky top-0 z-50">
+    <nav class="bg-white border-b border-[#E5E7EB] shadow-sm sticky top-0 z-50">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16">
                 <div class="flex-shrink-0">
-                    <a href="{% url 'gestor_tareas:lista_tareas' %}" class="text-white font-bold text-xl">Asistente <span class="text-cyan-400">PRO</span></a>
+                    <a href="{% url 'gestor_tareas:lista_tareas' %}" class="text-[#0F172A] font-bold text-xl">Asistente <span class="text-teal-600">PRO</span></a>
                 </div>
                 <!-- Menú de Escritorio -->
                 <div class="hidden md:block">
                     <div class="ml-10 flex items-baseline space-x-4">
                         {% with request.resolver_match.app_name as app_name %}
-                        <a href="{% url 'gestor_tareas:lista_tareas' %}" class="px-3 py-2 rounded-md text-sm font-medium {% if app_name == 'gestor_tareas' %} bg-slate-900 text-white {% else %} text-slate-300 hover:bg-slate-700 hover:text-white {% endif %}">Tareas</a>
-                        <a href="{% url 'interfaz:home' %}" class="px-3 py-2 rounded-md text-sm font-medium {% if app_name == 'interfaz' %} bg-slate-900 text-white {% else %} text-slate-300 hover:bg-slate-700 hover:text-white {% endif %}">Contabilidad</a>
-                        <a href="{% url 'interfaz:dashboard' %}" class="px-3 py-2 rounded-md text-sm font-medium {% if app_name == 'interfaz' %} bg-slate-900 text-white {% else %} text-slate-300 hover:bg-slate-700 hover:text-white {% endif %}">Dashboard</a>
+                        <a href="{% url 'gestor_tareas:lista_tareas' %}" class="px-3 py-2 rounded-md text-sm font-medium {% if app_name == 'gestor_tareas' %} text-teal-700 border-b-2 border-teal-600 {% else %} text-gray-600 hover:text-[#0F172A] {% endif %}">Tareas</a>
+                        <a href="{% url 'interfaz:home' %}" class="px-3 py-2 rounded-md text-sm font-medium {% if app_name == 'interfaz' %} text-teal-700 border-b-2 border-teal-600 {% else %} text-gray-600 hover:text-[#0F172A] {% endif %}">Contabilidad</a>
+                        <a href="{% url 'interfaz:dashboard' %}" class="px-3 py-2 rounded-md text-sm font-medium {% if app_name == 'interfaz' %} text-teal-700 border-b-2 border-teal-600 {% else %} text-gray-600 hover:text-[#0F172A] {% endif %}">Dashboard</a>
                         {% endwith %}
                     </div>
                 </div>
                 <!-- Botón Hamburguesa -->
                 <div class="-mr-2 flex md:hidden">
-                    <button id="mobile-menu-button" type="button" class="bg-slate-700 inline-flex items-center justify-center p-2 rounded-md text-slate-400 hover:text-white hover:bg-slate-600 focus:outline-none">
+                    <button id="mobile-menu-button" type="button" class="bg-gray-200 inline-flex items-center justify-center p-2 rounded-md text-gray-600 hover:text-[#0F172A] hover:bg-gray-300 focus:outline-none">
                         <svg id="icon-open" class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
                         <svg id="icon-close" class="hidden h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
                     </button>
@@ -51,9 +51,9 @@
         <div class="md:hidden hidden" id="mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
                 {% with request.resolver_match.app_name as app_name %}
-                <a href="{% url 'gestor_tareas:lista_tareas' %}" class="block px-3 py-2 rounded-md text-base font-medium {% if app_name == 'gestor_tareas' %} bg-slate-900 text-white {% else %} text-slate-300 hover:bg-slate-700 hover:text-white {% endif %}">Tareas</a>
-                <a href="{% url 'interfaz:home' %}" class="block px-3 py-2 rounded-md text-base font-medium {% if app_name == 'interfaz' %} bg-slate-900 text-white {% else %} text-slate-300 hover:bg-slate-700 hover:text-white {% endif %}">Contabilidad</a>
-                <a href="{% url 'interfaz:dashboard' %}" class="block px-3 py-2 rounded-md text-base font-medium {% if app_name == 'interfaz' %} bg-slate-900 text-white {% else %} text-slate-300 hover:bg-slate-700 hover:text-white {% endif %}">Dashboard</a>
+                <a href="{% url 'gestor_tareas:lista_tareas' %}" class="block px-3 py-2 rounded-md text-base font-medium {% if app_name == 'gestor_tareas' %} bg-teal-50 text-teal-700 {% else %} text-gray-600 hover:bg-gray-100 hover:text-[#0F172A] {% endif %}">Tareas</a>
+                <a href="{% url 'interfaz:home' %}" class="block px-3 py-2 rounded-md text-base font-medium {% if app_name == 'interfaz' %} bg-teal-50 text-teal-700 {% else %} text-gray-600 hover:bg-gray-100 hover:text-[#0F172A] {% endif %}">Contabilidad</a>
+                <a href="{% url 'interfaz:dashboard' %}" class="block px-3 py-2 rounded-md text-base font-medium {% if app_name == 'interfaz' %} bg-teal-50 text-teal-700 {% else %} text-gray-600 hover:bg-gray-100 hover:text-[#0F172A] {% endif %}">Dashboard</a>
                 {% endwith %}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- harmonize accounting dashboard and movement pages with task view theme
- prevent notes drawer from causing horizontal scroll and make it responsive
- show highlight and opacity cues when dragging tasks

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c0b2b111d4832caaa4c0845aa18769